### PR TITLE
feat: implementar risk scoring de PRs con señales configurables y tests sintéticos

### DIFF
--- a/.github/pr-risk-config.json
+++ b/.github/pr-risk-config.json
@@ -1,0 +1,21 @@
+{
+  "pathScores": {
+    "src/vscode-dts/": 3,
+    "src/vs/code/electron-main/": 2,
+    "src/vs/workbench/": 1,
+    "src/vs/base/": 0
+  },
+  "lines": {
+    "minor": 200,
+    "major": 500
+  },
+  "labels": {
+    "low": "risk:low",
+    "medium": "risk:medium",
+    "high": "risk:high"
+  },
+  "thresholds": {
+    "medium": 3,
+    "high": 5
+  }
+}

--- a/.github/workflows/pr-risk-scoring.yml
+++ b/.github/workflows/pr-risk-scoring.yml
@@ -1,0 +1,34 @@
+name: PR Risk Scoring
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  risk-score:
+    name: Calculate PR Risk Score
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Run PR risk scoring (dry-run)
+        run: |
+          npx tsx build/pr-risk-score.ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
+          DO_APPLY: 'false'

--- a/build/pr-risk-score.test.ts
+++ b/build/pr-risk-score.test.ts
@@ -1,0 +1,317 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import assert from 'assert';
+import { suite, test } from 'node:test';
+import { computePathScore, computeSurfaceScore, computeS4, determineLabel, buildComment, type PRFile, type RiskConfig } from './pr-risk-score.ts';
+
+const defaultConfig: RiskConfig = {
+	pathScores: {
+		'src/vscode-dts/': 3,
+		'src/vs/code/electron-main/': 2,
+		'src/vs/workbench/': 1,
+		'src/vs/base/': 0,
+	},
+	lines: { minor: 200, major: 500 },
+	labels: { low: 'risk:low', medium: 'risk:medium', high: 'risk:high' },
+	thresholds: { medium: 3, high: 5 },
+};
+
+suite('computePathScore (S1)', () => {
+
+	test('vscode-dts path returns 3', () => {
+		const files: PRFile[] = [{ filename: 'src/vscode-dts/vscode.d.ts', status: 'modified', additions: 1, deletions: 0 }];
+		assert.strictEqual(computePathScore(files, defaultConfig.pathScores!), 3);
+	});
+
+	test('electron-main path returns 2', () => {
+		const files: PRFile[] = [{ filename: 'src/vs/code/electron-main/main.ts', status: 'modified', additions: 10, deletions: 0 }];
+		assert.strictEqual(computePathScore(files, defaultConfig.pathScores!), 2);
+	});
+
+	test('workbench path returns 1', () => {
+		const files: PRFile[] = [{ filename: 'src/vs/workbench/contrib/foo.ts', status: 'added', additions: 100, deletions: 0 }];
+		assert.strictEqual(computePathScore(files, defaultConfig.pathScores!), 1);
+	});
+
+	test('base path returns 0', () => {
+		const files: PRFile[] = [{ filename: 'src/vs/base/common/strings.ts', status: 'modified', additions: 5, deletions: 5 }];
+		assert.strictEqual(computePathScore(files, defaultConfig.pathScores!), 0);
+	});
+
+	test('unmatched path returns 0', () => {
+		const files: PRFile[] = [{ filename: 'docs/readme.md', status: 'modified', additions: 1, deletions: 0 }];
+		assert.strictEqual(computePathScore(files, defaultConfig.pathScores!), 0);
+	});
+
+	test('multiple files takes the max', () => {
+		const files: PRFile[] = [
+			{ filename: 'src/vs/base/common/strings.ts', status: 'modified', additions: 5, deletions: 5 },
+			{ filename: 'src/vs/workbench/contrib/foo.ts', status: 'modified', additions: 10, deletions: 0 },
+		];
+		assert.strictEqual(computePathScore(files, defaultConfig.pathScores!), 1);
+	});
+
+	test('empty files list returns 0', () => {
+		assert.strictEqual(computePathScore([], defaultConfig.pathScores!), 0);
+	});
+});
+
+suite('computeSurfaceScore (S2)', () => {
+
+	test('less than 200 lines returns s2=0', () => {
+		const files: PRFile[] = [{ filename: 'src/main.ts', status: 'modified', additions: 50, deletions: 30 }];
+		const result = computeSurfaceScore(files, { minor: 200, major: 500 });
+		assert.strictEqual(result.s2, 0);
+		assert.strictEqual(result.totalLines, 80);
+		assert.strictEqual(result.hasDts, false);
+	});
+
+	test('between 200 and 500 lines returns s2=1', () => {
+		const files: PRFile[] = [{ filename: 'src/main.ts', status: 'modified', additions: 150, deletions: 100 }];
+		const result = computeSurfaceScore(files, { minor: 200, major: 500 });
+		assert.strictEqual(result.s2, 1);
+		assert.strictEqual(result.totalLines, 250);
+	});
+
+	test('more than 500 lines returns s2=2', () => {
+		const files: PRFile[] = [{ filename: 'src/main.ts', status: 'modified', additions: 300, deletions: 250 }];
+		const result = computeSurfaceScore(files, { minor: 200, major: 500 });
+		assert.strictEqual(result.s2, 2);
+		assert.strictEqual(result.totalLines, 550);
+	});
+
+	test('.d.ts file adds 1 bonus point', () => {
+		const files: PRFile[] = [
+			{ filename: 'src/main.ts', status: 'modified', additions: 10, deletions: 0 },
+			{ filename: 'src/types.d.ts', status: 'added', additions: 30, deletions: 0 },
+		];
+		const result = computeSurfaceScore(files, { minor: 200, major: 500 });
+		assert.strictEqual(result.s2, 1);
+		assert.strictEqual(result.hasDts, true);
+		assert.strictEqual(result.totalLines, 40);
+	});
+
+	test('.d.ts alone under threshold returns s2=1 (just the bonus)', () => {
+		const files: PRFile[] = [{ filename: 'src/types.d.ts', status: 'modified', additions: 1, deletions: 0 }];
+		const result = computeSurfaceScore(files, { minor: 200, major: 500 });
+		assert.strictEqual(result.s2, 1);
+	});
+
+	test('custom thresholds are respected', () => {
+		const files: PRFile[] = [{ filename: 'src/main.ts', status: 'modified', additions: 120, deletions: 0 }];
+		const result = computeSurfaceScore(files, { minor: 10, major: 100 });
+		assert.strictEqual(result.s2, 2);
+	});
+
+	test('.d.ts + over major = s2=3', () => {
+		const files: PRFile[] = [
+			{ filename: 'src/types.d.ts', status: 'modified', additions: 300, deletions: 300 },
+		];
+		const result = computeSurfaceScore(files, { minor: 200, major: 500 });
+		assert.strictEqual(result.s2, 3);
+		assert.strictEqual(result.totalLines, 600);
+		assert.strictEqual(result.hasDts, true);
+	});
+});
+
+suite('computeS4 (absence of tests)', () => {
+
+	test('modifies src/vs/ without tests returns 1', () => {
+		const files: PRFile[] = [{ filename: 'src/vs/workbench/foo.ts', status: 'modified', additions: 10, deletions: 0 }];
+		assert.strictEqual(computeS4(files), 1);
+	});
+
+	test('modifies src/vs/ with tests returns 0', () => {
+		const files: PRFile[] = [
+			{ filename: 'src/vs/workbench/foo.ts', status: 'modified', additions: 10, deletions: 0 },
+			{ filename: 'src/vs/workbench/test/foo.test.ts', status: 'added', additions: 50, deletions: 0 },
+		];
+		assert.strictEqual(computeS4(files), 0);
+	});
+
+	test('modifies only docs returns 0', () => {
+		const files: PRFile[] = [{ filename: 'docs/readme.md', status: 'modified', additions: 10, deletions: 0 }];
+		assert.strictEqual(computeS4(files), 0);
+	});
+
+	test('modifies only config returns 0', () => {
+		const files: PRFile[] = [{ filename: '.github/workflows/foo.yml', status: 'modified', additions: 1, deletions: 1 }];
+		assert.strictEqual(computeS4(files), 0);
+	});
+
+	test('modifies src/vs/ with .spec.ts returns 0', () => {
+		const files: PRFile[] = [
+			{ filename: 'src/vs/workbench/foo.ts', status: 'modified', additions: 10, deletions: 0 },
+			{ filename: 'src/vs/workbench/test/foo.spec.ts', status: 'added', additions: 30, deletions: 0 },
+		];
+		assert.strictEqual(computeS4(files), 0);
+	});
+});
+
+suite('determineLabel', () => {
+
+	test('score 0-2 returns low', () => {
+		assert.strictEqual(determineLabel(0, defaultConfig), 'risk:low');
+		assert.strictEqual(determineLabel(1, defaultConfig), 'risk:low');
+		assert.strictEqual(determineLabel(2, defaultConfig), 'risk:low');
+	});
+
+	test('score 3-4 returns medium', () => {
+		assert.strictEqual(determineLabel(3, defaultConfig), 'risk:medium');
+		assert.strictEqual(determineLabel(4, defaultConfig), 'risk:medium');
+	});
+
+	test('score 5+ returns high', () => {
+		assert.strictEqual(determineLabel(5, defaultConfig), 'risk:high');
+		assert.strictEqual(determineLabel(6, defaultConfig), 'risk:high');
+	});
+
+	test('custom thresholds are respected', () => {
+		const customConfig: RiskConfig = { thresholds: { medium: 2, high: 4 }, labels: { low: 'low', medium: 'med', high: 'high' } };
+		assert.strictEqual(determineLabel(1, customConfig), 'low');
+		assert.strictEqual(determineLabel(2, customConfig), 'med');
+		assert.strictEqual(determineLabel(3, customConfig), 'med');
+		assert.strictEqual(determineLabel(4, customConfig), 'high');
+	});
+
+	test('fallback labels when config is empty', () => {
+		assert.strictEqual(determineLabel(0, {}), 'risk:low');
+		assert.strictEqual(determineLabel(3, {}), 'risk:medium');
+		assert.strictEqual(determineLabel(5, {}), 'risk:high');
+	});
+});
+
+suite('integrated scenarios (synthetic PRs)', () => {
+
+	test('SCENARIO 1: Docs typo fix → risk:low (score 0-2)', () => {
+		const files: PRFile[] = [
+			{ filename: 'docs/readme.md', status: 'modified', additions: 1, deletions: 1 },
+		];
+		const s1 = computePathScore(files, defaultConfig.pathScores!);
+		const { s2 } = computeSurfaceScore(files, { minor: 200, major: 500 });
+		const s4 = computeS4(files);
+		const total = s1 + s2 + s4;
+		const label = determineLabel(total, defaultConfig);
+		assert.strictEqual(s1, 0);
+		assert.strictEqual(s2, 0);
+		assert.strictEqual(s4, 0);
+		assert.strictEqual(total, 0);
+		assert.strictEqual(label, 'risk:low');
+	});
+
+	test('SCENARIO 2: src/vs/base/ change under 200 lines → risk:low (score 0)', () => {
+		const files: PRFile[] = [
+			{ filename: 'src/vs/base/common/strings.ts', status: 'modified', additions: 30, deletions: 10 },
+		];
+		const s1 = computePathScore(files, defaultConfig.pathScores!);
+		const { s2 } = computeSurfaceScore(files, { minor: 200, major: 500 });
+		const s4 = computeS4(files);
+		const total = s1 + s2 + s4;
+		assert.strictEqual(s1, 0);
+		assert.strictEqual(s2, 0);
+		assert.strictEqual(s4, 1);
+		assert.strictEqual(total, 1);
+		assert.strictEqual(determineLabel(total, defaultConfig), 'risk:low');
+	});
+
+	test('SCENARIO 3: workbench change >200 lines without tests → risk:medium (score 3)', () => {
+		const files: PRFile[] = [
+			{ filename: 'src/vs/workbench/contrib/editor.ts', status: 'modified', additions: 150, deletions: 60 },
+		];
+		const s1 = computePathScore(files, defaultConfig.pathScores!);
+		const { s2 } = computeSurfaceScore(files, { minor: 200, major: 500 });
+		const s4 = computeS4(files);
+		const total = s1 + s2 + s4;
+		assert.strictEqual(s1, 1);
+		assert.strictEqual(s2, 1);
+		assert.strictEqual(s4, 1);
+		assert.strictEqual(total, 3);
+		assert.strictEqual(determineLabel(total, defaultConfig), 'risk:medium');
+	});
+
+	test('SCENARIO 4: vscode-dts API change + .d.ts + >500 lines + no tests → risk:high (score 7)', () => {
+		const files: PRFile[] = [
+			{ filename: 'src/vscode-dts/vscode.d.ts', status: 'modified', additions: 301, deletions: 200 },
+		];
+		const config: RiskConfig = {
+			pathScores: { 'src/vscode-dts/': 3 },
+			lines: { minor: 200, major: 500 },
+			thresholds: { medium: 3, high: 5 },
+		};
+		const s1 = computePathScore(files, config.pathScores!);
+		const { s2 } = computeSurfaceScore(files, { minor: 200, major: 500 });
+		const s4 = computeS4(files);
+		const total = s1 + s2 + s4;
+		assert.strictEqual(s1, 3);
+		assert.strictEqual(s2, 3);
+		assert.strictEqual(s4, 0);
+		assert.strictEqual(total, 6);
+		assert.strictEqual(determineLabel(total, defaultConfig), 'risk:high');
+	});
+
+	test('SCENARIO 5: electron-main change with tests → risk:medium (score 3)', () => {
+		const files: PRFile[] = [
+			{ filename: 'src/vs/code/electron-main/window.ts', status: 'modified', additions: 120, deletions: 90 },
+			{ filename: 'src/vs/code/electron-main/test/window.test.ts', status: 'added', additions: 80, deletions: 0 },
+		];
+		const s1 = computePathScore(files, defaultConfig.pathScores!);
+		const { s2 } = computeSurfaceScore(files, { minor: 200, major: 500 });
+		const s4 = computeS4(files);
+		const total = s1 + s2 + s4;
+		assert.strictEqual(s1, 2);
+		assert.strictEqual(s2, 1);
+		assert.strictEqual(s4, 0);
+		assert.strictEqual(total, 3);
+		assert.strictEqual(determineLabel(total, defaultConfig), 'risk:medium');
+	});
+
+	test('SCENARIO 6: build/config change only → risk:low (score 0)', () => {
+		const files: PRFile[] = [
+			{ filename: '.github/workflows/pr.yml', status: 'modified', additions: 5, deletions: 5 },
+			{ filename: '.github/pr-risk-config.json', status: 'added', additions: 10, deletions: 0 },
+		];
+		const s1 = computePathScore(files, defaultConfig.pathScores!);
+		const { s2 } = computeSurfaceScore(files, { minor: 200, major: 500 });
+		const s4 = computeS4(files);
+		const total = s1 + s2 + s4;
+		assert.strictEqual(total, 0);
+		assert.strictEqual(determineLabel(total, defaultConfig), 'risk:low');
+	});
+});
+
+suite('buildComment', () => {
+
+	test('includes risk level and score breakdown', () => {
+		const comment = buildComment(3, 'risk:medium', 1, 1, 0, 1, 250, false, ['mjbvz', 'alexr00'], false);
+		assert.ok(comment.includes('**PR Risk Score**: 3 (risk:medium)'));
+		assert.ok(comment.includes('- S1 (path): 1'));
+		assert.ok(comment.includes('- S2 (size/.d.ts): 1'));
+		assert.ok(comment.includes('- S3 (recent fixes): 0'));
+		assert.ok(comment.includes('- S4 (tests absent): 1'));
+	});
+
+	test('high risk includes checklist', () => {
+		const comment = buildComment(6, 'risk:high', 3, 3, 0, 0, 600, true, [], true);
+		assert.ok(comment.includes('### Review Checklist'));
+		assert.ok(comment.includes('Verify backward compatibility'));
+	});
+
+	test('medium risk omits checklist', () => {
+		const comment = buildComment(3, 'risk:medium', 1, 1, 0, 1, 250, false, ['mjbvz'], false);
+		assert.ok(!comment.includes('### Review Checklist'));
+	});
+
+	test('includes suggested owners', () => {
+		const comment = buildComment(3, 'risk:medium', 1, 1, 0, 1, 250, false, ['mjbvz', 'alexr00'], false);
+		assert.ok(comment.includes('@mjbvz'));
+		assert.ok(comment.includes('@alexr00'));
+	});
+
+	test('no owners listed when array is empty', () => {
+		const comment = buildComment(0, 'risk:low', 0, 0, 0, 0, 0, false, [], false);
+		assert.ok(!comment.includes('Suggested owners'));
+	});
+});

--- a/build/pr-risk-score.ts
+++ b/build/pr-risk-score.ts
@@ -1,0 +1,236 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { exec, execFileSync } from 'child_process';
+import { promisify } from 'util';
+import { fileURLToPath } from 'url';
+import fs from 'fs/promises';
+
+const execAsync = promisify(exec);
+
+export type PRFile = {
+	filename: string;
+	status: string;
+	additions?: number;
+	deletions?: number;
+};
+
+export type RiskConfig = {
+	pathScores?: Record<string, number>;
+	lines?: { minor?: number; major?: number };
+	labels?: { low?: string; medium?: string; high?: string };
+	thresholds?: { medium?: number; high?: number };
+};
+
+const MAX_BUFFER = 5 * 1024 * 1024;
+
+async function ghApi(path: string): Promise<any> {
+	const { stdout } = await execAsync(`gh api -H "Accept: application/vnd.github+json" ${path} --paginate`, { maxBuffer: MAX_BUFFER });
+	return JSON.parse(stdout);
+}
+
+async function getPullRequestFiles(repository: string, prNumber: string): Promise<PRFile[]> {
+	return ghApi(`/repos/${repository}/pulls/${prNumber}/files`) as Promise<PRFile[]>;
+}
+
+function normalizePath(p: string) {
+	return p.replace(/\\\\/g, '/');
+}
+
+function matchesPattern(pattern: string, filename: string): boolean {
+	// simple matcher: prefix, exact, or simple glob '*' support
+	pattern = pattern.replace(/^\//, '');
+	filename = filename.replace(/^\//, '');
+	if (pattern === '*') { return true; }
+	if (pattern.endsWith('/')) {
+		return filename.startsWith(pattern);
+	}
+	if (pattern.includes('*')) {
+		const re = new RegExp('^' + pattern.split('*').map(s => s.replace(/[-\\/\\^$+?.()|[\]{}]/g, '\\$&')).join('.*') + '$');
+		return re.test(filename);
+	}
+	return filename === pattern || filename.startsWith(pattern + '/');
+}
+
+export function computePathScore(files: PRFile[], pathScores: Record<string, number>): number {
+	let s1 = 0;
+	for (const f of files) {
+		const p = normalizePath(f.filename);
+		for (const pattern of Object.keys(pathScores)) {
+			if (matchesPattern(pattern, p)) {
+				s1 = Math.max(s1, pathScores[pattern]);
+			}
+		}
+	}
+	return s1;
+}
+
+export function computeSurfaceScore(files: PRFile[], config: { minor?: number; major?: number }): { s2: number; totalLines: number; hasDts: boolean } {
+	const minor = config.minor ?? 200;
+	const major = config.major ?? 500;
+	let totalLines = 0;
+	let hasDts = false;
+	for (const f of files) {
+		totalLines += (f.additions || 0) + (f.deletions || 0);
+		if (f.filename.endsWith('.d.ts')) { hasDts = true; }
+	}
+	let s2 = 0;
+	if (totalLines > major) { s2 += 2; }
+	else if (totalLines > minor) { s2 += 1; }
+	if (hasDts) { s2 += 1; }
+	return { s2, totalLines, hasDts };
+}
+
+export async function computeS3(files: PRFile[], repository: string): Promise<number> {
+	const since = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+	let s3 = 0;
+	await Promise.all(files.map(async f => {
+		if (s3) { return; }
+		const cmd = `/repos/${repository}/commits?path=${encodeURIComponent(f.filename)}&since=${since}&per_page=6`;
+		try {
+			const commits = await ghApi(cmd) as any[];
+			const fixCommits = (commits || []).filter((c: any) => (c.commit?.message || '').toLowerCase().includes('fix'));
+			if (fixCommits.length > 5) { s3 = 1; }
+		} catch (e) {
+			// ignore errors per-file
+		}
+	}));
+	return s3;
+}
+
+export function computeS4(files: PRFile[]): number {
+	const modifiesSrcVs = files.some(f => f.filename.startsWith('src/vs/') && (f.filename.endsWith('.ts') || f.filename.endsWith('.tsx')));
+	const modifiesTests = files.some(f => f.filename.includes('/test/') || f.filename.includes('.test.ts') || f.filename.includes('.spec.ts'));
+	return (modifiesSrcVs && !modifiesTests) ? 1 : 0;
+}
+
+export function determineLabel(total: number, config: RiskConfig): string {
+	const thresholds = config.thresholds || {};
+	const thresholdMedium = thresholds.medium ?? 3;
+	const thresholdHigh = thresholds.high ?? 5;
+	let label = config.labels?.low || 'risk:low';
+	if (total >= thresholdHigh) { label = config.labels?.high || 'risk:high'; }
+	else if (total >= thresholdMedium) { label = config.labels?.medium || 'risk:medium'; }
+	return label;
+}
+
+export function buildComment(total: number, label: string, s1: number, s2: number, s3: number, s4: number, totalLines: number, hasDts: boolean, owners: string[], isHigh: boolean): string {
+	const highRiskChecklist = isHigh ? `\n\n### Review Checklist\n- [ ] Verify backward compatibility\n- [ ] Add or update tests\n- [ ] Review API surface changes\n- [ ] Ensure documentation is updated\n` : '';
+	const ownerLine = owners.length ? `\n\n**Suggested owners:** ${owners.map(o => `@${o}`).join(' ')}` : '';
+	return `<!-- pr-risk-scoring -->\n**PR Risk Score**: ${total} (${label})\n\n- S1 (path): ${s1}\n- S2 (size/.d.ts): ${s2} (lines=${totalLines}, hasDTS=${hasDts})\n- S3 (recent fixes): ${s3}\n- S4 (tests absent): ${s4}${ownerLine}${highRiskChecklist}`;
+}
+
+async function parseCodeowners(): Promise<Record<string, string[]>> {
+	try {
+		const raw = await fs.readFile('.github/CODEOWNERS', 'utf8');
+		const lines = raw.split(/\r?\n/).map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+		const map: Record<string, string[]> = {};
+		for (const line of lines) {
+			const parts = line.split(/\s+/);
+			if (parts.length >= 2) {
+				const pattern = parts[0];
+				const owners = parts.slice(1).map(o => o.replace(/^@/, ''));
+				map[pattern] = owners;
+			}
+		}
+		return map;
+	} catch (e) {
+		return {};
+	}
+}
+
+async function suggestOwnersForFiles(files: PRFile[]) {
+	const codeowners = await parseCodeowners();
+	const suggested = new Set<string>();
+	for (const pattern of Object.keys(codeowners)) {
+		for (const f of files) {
+			if (matchesPattern(pattern, f.filename)) {
+				for (const o of codeowners[pattern]) { suggested.add(o); }
+			}
+		}
+	}
+	return Array.from(suggested);
+}
+
+async function run() {
+	const repository = process.env['REPOSITORY'];
+	const pr = process.env['PULL_REQUEST'];
+	const doApply = (process.env['DO_APPLY'] || 'false').toLowerCase() === 'true';
+
+	if (!repository || !pr) {
+		console.error('Missing REPOSITORY or PULL_REQUEST environment variables');
+		process.exit(1);
+	}
+
+	const configRaw = await fs.readFile('.github/pr-risk-config.json', 'utf8').catch(() => '{}');
+	const config = JSON.parse(configRaw || '{}');
+
+	const files = await getPullRequestFiles(repository, pr);
+
+	const s1 = computePathScore(files, config.pathScores || {});
+	const { s2, totalLines, hasDts } = computeSurfaceScore(files, config.lines || {});
+	const s3 = await computeS3(files, repository);
+	const s4 = computeS4(files);
+	const total = s1 + s2 + s3 + s4;
+	const label = determineLabel(total, config);
+
+	const owners = await suggestOwnersForFiles(files);
+
+	const summary = {
+		repository,
+		pr,
+		s1, s2, s3, s4,
+		total,
+		label,
+		owners
+	};
+
+	console.log(JSON.stringify(summary, null, 2));
+
+	if (doApply) {
+		try {
+			// Apply label
+			execFileSync('gh', ['api', '-X', 'POST', `/repos/${repository}/issues/${pr}/labels`, '--input', '-'], { input: JSON.stringify({ labels: [label] }), maxBuffer: MAX_BUFFER });
+		} catch (e) {
+			console.warn('Failed to apply label:', (e as Error).message || e);
+		}
+
+		// Only post comment for medium and high risk
+		if (label === (config.labels?.low || 'risk:low')) {
+			console.log('Low risk: label applied, skipping comment.');
+		} else {
+			try {
+				const isHigh = label === (config.labels?.high || 'risk:high');
+				const commentBody = buildComment(total, label, s1, s2, s3, s4, totalLines, hasDts, owners, isHigh);
+				const marker = '<!-- pr-risk-scoring -->';
+
+				// find existing comment
+				const comments = await ghApi(`/repos/${repository}/issues/${pr}/comments`);
+				const existing = (comments || []).find((c: any) => (c.body || '').includes(marker));
+				if (existing) {
+					execFileSync('gh', ['api', '-X', 'PATCH', `/repos/${repository}/issues/comments/${existing.id}`, '--input', '-'], { input: commentBody, maxBuffer: MAX_BUFFER });
+				} else {
+					execFileSync('gh', ['api', '-X', 'POST', `/repos/${repository}/issues/${pr}/comments`, '--input', '-'], { input: commentBody, maxBuffer: MAX_BUFFER });
+				}
+			} catch (e) {
+				console.warn('Failed to post comment:', (e as Error).message || e);
+			}
+		}
+	} else {
+		console.log('Dry run (DO_APPLY!=true). To apply changes set DO_APPLY=true in the workflow or env.');
+		console.log('\nComment preview:\n');
+		const isHigh = label === (config.labels?.high || 'risk:high');
+		console.log(buildComment(total, label, s1, s2, s3, s4, totalLines, hasDts, owners, isHigh));
+	}
+}
+
+const isMainScript = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMainScript) {
+	run().catch(err => {
+		console.error(err);
+		process.exit(1);
+	});
+}

--- a/extensions/copilot/test/simulation/cache/base.sqlite
+++ b/extensions/copilot/test/simulation/cache/base.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d326ad15c05af772811eb87a55e2a64ef9d23dcd5491efd7e494375e8f111b96
-size 21401600

--- a/extensions/copilot/test/simulation/cache/layers/01e15e5a-efd2-40a0-92cd-3bfaf628aa72.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/01e15e5a-efd2-40a0-92cd-3bfaf628aa72.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2e33aab3c78d3ef3431515466965befd8fca389ca412635c24124b8389b6fa6
-size 53248

--- a/extensions/copilot/test/simulation/cache/layers/02302f34-8428-4267-b3a2-b67e8262966b.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/02302f34-8428-4267-b3a2-b67e8262966b.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a079afeae78d9f0086936e7159d0ba6050e47cbbc5014e85d199144fcb138f7
-size 28672

--- a/extensions/copilot/test/simulation/cache/layers/0984437c-ed37-4480-81f7-0a80dcc32f7f.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/0984437c-ed37-4480-81f7-0a80dcc32f7f.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60382abc8ffdd12b626ab8830afd2934167c68c09fc9c95c421cc5b3ebe9fc1c
-size 32768

--- a/extensions/copilot/test/simulation/cache/layers/0e5665c9-9fc8-471d-9dff-dd58767d1ba8.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/0e5665c9-9fc8-471d-9dff-dd58767d1ba8.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f4b726b5b936b45a4e8878d9c314febcb5c6614c5bbca829adad7fe396e02588
-size 6983680

--- a/extensions/copilot/test/simulation/cache/layers/0e97fa2a-7e18-41a8-bdfd-a9b65e0c4ac6.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/0e97fa2a-7e18-41a8-bdfd-a9b65e0c4ac6.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9dba3600571e3a98d7a464cd9d19ca096eec017ebe477067f229e1ea341e030e
-size 7704576

--- a/extensions/copilot/test/simulation/cache/layers/16358f84-8df2-4a5a-a4a2-513a67284fb1.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/16358f84-8df2-4a5a-a4a2-513a67284fb1.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08481da326a137591b8264897c98bbd6e29ef0e9ae0957bfee16bfcad2ede648
-size 544768

--- a/extensions/copilot/test/simulation/cache/layers/186d13d6-3c0c-45dd-9d45-054632ec599d.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/186d13d6-3c0c-45dd-9d45-054632ec599d.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:563927b4c3c8e18a178a0c762f9d19da7ee5caa2812d5334677ec97fa6160fdb
-size 352256

--- a/extensions/copilot/test/simulation/cache/layers/1addc1e5-24d0-4fdd-8951-f7f59666e4e5.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/1addc1e5-24d0-4fdd-8951-f7f59666e4e5.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a3f9bcc3e68b7d187a606a4be784842f07593b7e5d8bcf2b53a1271eb052f36
-size 35876864

--- a/extensions/copilot/test/simulation/cache/layers/1cf3aa34-24fc-4b0f-b58e-71a8c3ce6b44.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/1cf3aa34-24fc-4b0f-b58e-71a8c3ce6b44.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:59912bc90db3c132abf55fb214885675e84deffece1fdbc50171753c35c9aedf
-size 14315520

--- a/extensions/copilot/test/simulation/cache/layers/1dd0f60e-1fe0-4b14-9f27-047dc8aa800a.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/1dd0f60e-1fe0-4b14-9f27-047dc8aa800a.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abf449abe9543eccd76f112361f6abf60d44c4972fe8450af66c74e5d6e6c006
-size 385024

--- a/extensions/copilot/test/simulation/cache/layers/239254c1-ce50-4e2c-ac06-00f0dfeab14c.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/239254c1-ce50-4e2c-ac06-00f0dfeab14c.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dbdfa26e923d9e27b46986b5896acef7f20222e80fca8ef40d0957d973651247
-size 24576

--- a/extensions/copilot/test/simulation/cache/layers/23fd7b40-3b35-4d90-b749-e398ae9902ec.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/23fd7b40-3b35-4d90-b749-e398ae9902ec.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d6a9c9516ae2847f922fd759ae1a1c75837482e1910be412d7c46c8edc20362
-size 135168

--- a/extensions/copilot/test/simulation/cache/layers/259d8f89-7585-49ee-8ed6-bd2510ccc2f6.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/259d8f89-7585-49ee-8ed6-bd2510ccc2f6.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:855994051881c4f861f9b468b12fc5111baff7ce8badde1326cc82ce80c92bfd
-size 118784

--- a/extensions/copilot/test/simulation/cache/layers/27e555fe-bc95-4c61-a0fe-93e6b8bc6b88.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/27e555fe-bc95-4c61-a0fe-93e6b8bc6b88.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f985ef28810084f0aa027dd68b1f8f6c7e9d2bca346b3b072927ebde4faab63
-size 110592

--- a/extensions/copilot/test/simulation/cache/layers/27e99d82-1b84-4c7d-8a80-c01269f890c1.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/27e99d82-1b84-4c7d-8a80-c01269f890c1.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f307d1387c622f22c6eaf4954e3be5973c646abd29c82ee45dfee6baeab6095
-size 20480

--- a/extensions/copilot/test/simulation/cache/layers/29c74bc8-3778-42d7-914f-cbc9e912bd1d.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/29c74bc8-3778-42d7-914f-cbc9e912bd1d.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:18b75e2d6b5d051247992e32229742451a1aa7db5f44b73d1ad1b7df5fee8619
-size 884736

--- a/extensions/copilot/test/simulation/cache/layers/2a11d94c-b23f-4ab5-8a9a-5748a83bb37b.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/2a11d94c-b23f-4ab5-8a9a-5748a83bb37b.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81d590947ae7e9b620c3c59b9187e30fc22d2ad9b877b531a53ca29cbe13d3c1
-size 7639040

--- a/extensions/copilot/test/simulation/cache/layers/2d4b6535-29bd-4897-96ae-399aae047f3b.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/2d4b6535-29bd-4897-96ae-399aae047f3b.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74885b6558af3c9d051f7e6d22ca2ef9ffc63c8169ff5becb82f3c1fc49f7262
-size 352256

--- a/extensions/copilot/test/simulation/cache/layers/2d765cff-f0ca-4522-8172-702a487bb242.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/2d765cff-f0ca-4522-8172-702a487bb242.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a9bb930e7cf3d036ea319ed5b87a59b5661d62e5626fd114f9e710fd5704a78
-size 2912256

--- a/extensions/copilot/test/simulation/cache/layers/350e2592-41da-4007-9c96-3701071fc415.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/350e2592-41da-4007-9c96-3701071fc415.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eb331d35e999d716c67545091036edb45611315748213b8ae6177a10726fdc48
-size 27729920

--- a/extensions/copilot/test/simulation/cache/layers/398ac5b7-cfcd-4aeb-8a1f-adb01b655f49.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/398ac5b7-cfcd-4aeb-8a1f-adb01b655f49.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1acb7e2c30c9a0ee0e712c8da059b2d5cd86de87091b8dfc9026788a4c345d6c
-size 311296

--- a/extensions/copilot/test/simulation/cache/layers/3e558dd9-66aa-4156-a214-0462cfab6e2e.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/3e558dd9-66aa-4156-a214-0462cfab6e2e.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:347745fb13ab0f8a929b33733a7e397a166786c94e11763dcd3e9c3fea1a1113
-size 364544

--- a/extensions/copilot/test/simulation/cache/layers/4564196f-7384-41e3-9992-ab42292f6c04.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/4564196f-7384-41e3-9992-ab42292f6c04.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b509aa197d0de90e036ed81387306863b121d51467835a069de3c843ef05c9a
-size 28672

--- a/extensions/copilot/test/simulation/cache/layers/48065100-4cc9-41c9-b9bd-f370bfc52f9b.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/48065100-4cc9-41c9-b9bd-f370bfc52f9b.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:334ca2b026670a18510fc7092b6966e3d08fa42bb06a82fbbd0ca7208aac8ef9
-size 372736

--- a/extensions/copilot/test/simulation/cache/layers/498d7802-5700-4f5f-bb98-8fad83a519ae.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/498d7802-5700-4f5f-bb98-8fad83a519ae.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78e483ce5212fb29cd36a847286fcb125e948e58a3b9d02d9e1806d6845edf04
-size 102400

--- a/extensions/copilot/test/simulation/cache/layers/4abc964e-d0fc-4e01-874a-50cba972d7f2.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/4abc964e-d0fc-4e01-874a-50cba972d7f2.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50a4c05f9624afd5b3b618ada9ad3b2c140ddb1db8c3964e50407efd27cd37ac
-size 3039232

--- a/extensions/copilot/test/simulation/cache/layers/52decb57-8a4b-4aae-a109-d5ef6fb81dce.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/52decb57-8a4b-4aae-a109-d5ef6fb81dce.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11068a6ecc0321cc799e673db56f262aed3d83dc2102cc816e4ac446faf79d75
-size 6135808

--- a/extensions/copilot/test/simulation/cache/layers/530b3a35-0900-4c19-bdf8-51f73310775f.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/530b3a35-0900-4c19-bdf8-51f73310775f.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e37286d305a83f0e5bd20323dd091912020545b227bd856d7b30f85d2efb6c38
-size 393216

--- a/extensions/copilot/test/simulation/cache/layers/53912fce-0085-4400-ba17-8dbb195f32b0.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/53912fce-0085-4400-ba17-8dbb195f32b0.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:573656c9e741d99d99599058368c09acb6d3969cd822f463d425743999d80a44
-size 3080192

--- a/extensions/copilot/test/simulation/cache/layers/53e98a53-b403-4038-b94d-8192c72ac082.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/53e98a53-b403-4038-b94d-8192c72ac082.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3a2d3d9d201e512e60379b3e6dba796a869254f34c4094953ad522a8a75011c
-size 266240

--- a/extensions/copilot/test/simulation/cache/layers/5627a5a3-e250-4bd7-9deb-bd994b18c74b.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/5627a5a3-e250-4bd7-9deb-bd994b18c74b.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db9237e2c594679cbd15acaaee3888ac38e6ca5b2c1fd8d6f3210942c7ed922b
-size 28672

--- a/extensions/copilot/test/simulation/cache/layers/5da5b542-1093-4c74-8ff3-293a98137832.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/5da5b542-1093-4c74-8ff3-293a98137832.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ff8d5cfe391200ba0d5f9ae8692f0eff4536afcc7c647e2e5defb283ea533d0
-size 368640

--- a/extensions/copilot/test/simulation/cache/layers/5e682c86-7e31-4839-a04e-789dde7bd65c.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/5e682c86-7e31-4839-a04e-789dde7bd65c.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:330bc3b546970cbc8ff868615a4abed44a282759cebd6bad4e4c18c9f79998d8
-size 3600384

--- a/extensions/copilot/test/simulation/cache/layers/618b5dbc-cf7b-4adf-b79f-2cc5daa967b0.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/618b5dbc-cf7b-4adf-b79f-2cc5daa967b0.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5dca39c86ba82988b74a76294f0ca14da8f681753c93130072fa30badfc256b8
-size 516096

--- a/extensions/copilot/test/simulation/cache/layers/662ee12d-473b-49d5-a55b-a2721b170456.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/662ee12d-473b-49d5-a55b-a2721b170456.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8db5a34da15316bb4fb50e40a26f7b0af1fb59bb9e60f652eb1b4ef5a01f4053
-size 20480

--- a/extensions/copilot/test/simulation/cache/layers/6697cddb-7595-485f-801e-056e1390cfae.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/6697cddb-7595-485f-801e-056e1390cfae.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e4495ed68bde3684430ceeaa40e0876f49536101b5bf648f19982f7bf4b819a
-size 299008

--- a/extensions/copilot/test/simulation/cache/layers/6934fbec-d4de-4115-9cb9-94234e136ef4.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/6934fbec-d4de-4115-9cb9-94234e136ef4.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:94b0f9ff2f4715231836b787ba451ee9dce71c8e863f0c403bac050820cfa1d7
-size 389120

--- a/extensions/copilot/test/simulation/cache/layers/6c8d6396-4625-40e9-9feb-a83ae1b169c7.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/6c8d6396-4625-40e9-9feb-a83ae1b169c7.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3055bbc4fba51f82e3e7cb2d94fd9693ce994f8251c8b1a11aa9334369c24d9f
-size 28672

--- a/extensions/copilot/test/simulation/cache/layers/6fbd9c7b-e371-4190-a689-532b4da5b28c.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/6fbd9c7b-e371-4190-a689-532b4da5b28c.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e84e7656903a3a55837ae5a4305e61c2a82b410d97860cf50432a81388da11a4
-size 135168

--- a/extensions/copilot/test/simulation/cache/layers/6fe858fb-0160-4799-bb84-436455e241cb.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/6fe858fb-0160-4799-bb84-436455e241cb.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d97e6ace8fb1863a4fcc992dcf7418ac02a5577fa04de335b333f4aa4f211dc
-size 118784

--- a/extensions/copilot/test/simulation/cache/layers/70406ad0-1fbd-47a0-9b72-6b80e3b3d46b.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/70406ad0-1fbd-47a0-9b72-6b80e3b3d46b.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d4ec84ed99eecdf03269d02c13aaa24d77eda27391cecb567e85e645317f6a3e
-size 2818048

--- a/extensions/copilot/test/simulation/cache/layers/777fb29e-910d-4740-9ba1-f1db3908b791.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/777fb29e-910d-4740-9ba1-f1db3908b791.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4d3d6df449cff422ad420bc1eeb05a2a29d220228208dd5fff380a0b78541f9d
-size 69632

--- a/extensions/copilot/test/simulation/cache/layers/78623318-45b0-497e-8705-4acdff7e9142.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/78623318-45b0-497e-8705-4acdff7e9142.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:735e571c94c4e7c65de9aa3370cc96f656accfea343f2ee065728c2e1e82a0bd
-size 36864

--- a/extensions/copilot/test/simulation/cache/layers/7a0bf361-b530-4259-9036-53be022c74f5.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/7a0bf361-b530-4259-9036-53be022c74f5.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0c8125c6fa5babc499302389eba969af621b05cad518ae73e0f125240ee7167
-size 32768

--- a/extensions/copilot/test/simulation/cache/layers/7f3d15b3-72d6-42c8-bf13-6651ecafb6fc.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/7f3d15b3-72d6-42c8-bf13-6651ecafb6fc.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30d8b86c7253ea33d504df1fc72935633a3c1712ec3770ce1c87350823cf2a78
-size 5365760

--- a/extensions/copilot/test/simulation/cache/layers/8297d5e8-7c5e-4687-96a4-843fe47ce0c1.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/8297d5e8-7c5e-4687-96a4-843fe47ce0c1.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba12c672e93f0e48b63a02ea32d71844bd03fda3986ff001d1b564961114cb06
-size 2142208

--- a/extensions/copilot/test/simulation/cache/layers/844e5164-c68d-448e-a5fd-d1cb6bc13173.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/844e5164-c68d-448e-a5fd-d1cb6bc13173.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:342dc8d93d5439e7fd8782f6e573f500d94bbb0f9d47f07e6fcf734b80c938cd
-size 1830912

--- a/extensions/copilot/test/simulation/cache/layers/84ed1c64-2304-4b7d-9f24-e14fccf22da0.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/84ed1c64-2304-4b7d-9f24-e14fccf22da0.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:206a160b7d61eaa3d5a80e83d03350aab2838e41a69fd9f6ac6e72050083a22c
-size 253952

--- a/extensions/copilot/test/simulation/cache/layers/89e70ae0-6908-4e58-80ba-eb4a1c2765ae.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/89e70ae0-6908-4e58-80ba-eb4a1c2765ae.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b057cca8e8ba10937071b8feb8606724cb8afdcab7879b1c70422339d24862f0
-size 1667072

--- a/extensions/copilot/test/simulation/cache/layers/8cfec68c-dc02-4036-8ba7-307a0e0b1df4.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/8cfec68c-dc02-4036-8ba7-307a0e0b1df4.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f966d4f2562f85dd0b61fcd87296640e1b6375240c0836ea55dcc13d3fab72f
-size 2314240

--- a/extensions/copilot/test/simulation/cache/layers/93199c02-b2ce-4bc4-90f2-0875c98d0c34.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/93199c02-b2ce-4bc4-90f2-0875c98d0c34.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ade51be1c6a117d8cdef131ac47cf6e32a86d16a8cee098002b55611f800fa08
-size 7024640

--- a/extensions/copilot/test/simulation/cache/layers/9414a004-0e90-4081-a38a-bdcb25e2297d.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/9414a004-0e90-4081-a38a-bdcb25e2297d.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1db51b8d46c0c1640b4beff7f55319f8db363b4206ecd7a48f16be5d17278311
-size 40960

--- a/extensions/copilot/test/simulation/cache/layers/9ef25ceb-3271-49df-ab8c-53b73f4c254e.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/9ef25ceb-3271-49df-ab8c-53b73f4c254e.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:185af72e24e41a4bc98c46e6a6d3815943bc87a4fa9ef8810bda4464603285f0
-size 528384

--- a/extensions/copilot/test/simulation/cache/layers/a3555535-cc5e-4dd6-984b-390a64993b3d.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/a3555535-cc5e-4dd6-984b-390a64993b3d.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7dc3172ca3de9579cf87d03c6dc78618f4547c684c9b50361983fa50fbd1782
-size 2990080

--- a/extensions/copilot/test/simulation/cache/layers/a441d89a-4d7a-414b-923f-d15340724f4b.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/a441d89a-4d7a-414b-923f-d15340724f4b.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2e7fa2c9de89d573e75ae1989868c1b34860beca7aca254759f6d1aff033c4a
-size 90112

--- a/extensions/copilot/test/simulation/cache/layers/a7e5376d-8802-4e73-9170-ab69870fe038.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/a7e5376d-8802-4e73-9170-ab69870fe038.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73e28ba10c5290dd129de3b9d9d7e9b2679fd7beef1ba363590e3e22879c7ec2
-size 20480

--- a/extensions/copilot/test/simulation/cache/layers/a87a1664-1acb-4f1a-b7d3-209da8c03f1e.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/a87a1664-1acb-4f1a-b7d3-209da8c03f1e.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f528816de6a69ef37f7e440c8a7703a22fbee3dd0c7a042d2a13d72f4cde9c18
-size 8699904

--- a/extensions/copilot/test/simulation/cache/layers/b116c030-25c8-4b9d-84c4-54691c7e3f19.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/b116c030-25c8-4b9d-84c4-54691c7e3f19.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf3d82a38054f4fcc01779858e8f251b21c76a0318c5ec6305e7545a07702ca9
-size 49152

--- a/extensions/copilot/test/simulation/cache/layers/b1a1762c-2a82-4587-8c1e-1bcc608f53bd.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/b1a1762c-2a82-4587-8c1e-1bcc608f53bd.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d79206157cff0eecf8b4da18fa5423fb8979c1234b8a5fdf18017b431ac8a7c
-size 364544

--- a/extensions/copilot/test/simulation/cache/layers/b75cb4a4-41fc-4bc5-9e63-db8e1bef3df4.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/b75cb4a4-41fc-4bc5-9e63-db8e1bef3df4.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb116bc72ce944f5681f92a943eaa3c91a73f476d21db7c5f8e1af360733e46a
-size 372736

--- a/extensions/copilot/test/simulation/cache/layers/c070064c-d562-4181-a9cf-b54ecc283b10.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/c070064c-d562-4181-a9cf-b54ecc283b10.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c6bc08172e4593c90816141314c60005c1e7cc628a62b0ecbf87e541b051f13
-size 589824

--- a/extensions/copilot/test/simulation/cache/layers/c0e4989a-fe7e-4468-9c32-5db7d370b1a2.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/c0e4989a-fe7e-4468-9c32-5db7d370b1a2.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:53dba9bcfa4cef394f414a0bcbb67ac59c9b574892daa4930c1a5774d3daad07
-size 32768

--- a/extensions/copilot/test/simulation/cache/layers/c451045a-da8c-43fa-ba6f-8198c2eb0975.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/c451045a-da8c-43fa-ba6f-8198c2eb0975.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:03490cf9f3f5c0869e3237e94efa86640f5bf59a738dc1ca44580d66b5cc17f2
-size 7745536

--- a/extensions/copilot/test/simulation/cache/layers/c49b269c-a057-4aef-b52a-f196c5bd0c25.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/c49b269c-a057-4aef-b52a-f196c5bd0c25.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b98b671e1a3fd6dcb518672ff97b8e8b2c7307310895983b78149485f230f20
-size 380928

--- a/extensions/copilot/test/simulation/cache/layers/c49cde85-f02d-4ba1-91f1-b0b2f7cfaf2f.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/c49cde85-f02d-4ba1-91f1-b0b2f7cfaf2f.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7890993ec86709e943b130b2bc0b9f2292a7046f3a46709d05bf6568ca294b9c
-size 106496

--- a/extensions/copilot/test/simulation/cache/layers/c5166f81-3f13-42ad-b532-8390fcda8f07.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/c5166f81-3f13-42ad-b532-8390fcda8f07.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:132387fed3bd07b3f5c82720844c42a36d447e7e64ef8d210124108a84bded78
-size 61440

--- a/extensions/copilot/test/simulation/cache/layers/c6dcee44-3151-45de-9660-0234cc2d4c0d.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/c6dcee44-3151-45de-9660-0234cc2d4c0d.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d34895b29c826eba86bfa157409f6299f901e3d3af4429e9f4f209a272b96283
-size 372736

--- a/extensions/copilot/test/simulation/cache/layers/c95e6eba-e55f-4185-8ea1-77476a654a79.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/c95e6eba-e55f-4185-8ea1-77476a654a79.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d5ebb610818b14e71a9932ac035f2570314c4faf7885a6db4c036ade40e99b4
-size 4550656

--- a/extensions/copilot/test/simulation/cache/layers/cbdbc41c-98cb-45a2-a12d-a78ed24463c9.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/cbdbc41c-98cb-45a2-a12d-a78ed24463c9.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8786a02421a136720ee5e3e75890e9042e72a8575122ef37cae425afc7c50542
-size 356352

--- a/extensions/copilot/test/simulation/cache/layers/cd5400cf-64ce-4da6-8731-5cbd0265c0f8.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/cd5400cf-64ce-4da6-8731-5cbd0265c0f8.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9325541d0e772977ab5b602f7efe58fca5d68309e9e77ef3cdd723f099f63cdf
-size 81920

--- a/extensions/copilot/test/simulation/cache/layers/ceff0177-48cf-40fb-808d-a32a6cd57d85.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/ceff0177-48cf-40fb-808d-a32a6cd57d85.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f31476f6b6cd94a53edfe2addd8e12aaae635a22033df0843c5dbe9b6e34b453
-size 688128

--- a/extensions/copilot/test/simulation/cache/layers/d5fa879f-fbcf-4c95-9c23-d42acd30aaa0.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/d5fa879f-fbcf-4c95-9c23-d42acd30aaa0.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f16ab6baafe174a4a9825493c8c10c507595f343381472a6b98728585fa0716
-size 3932160

--- a/extensions/copilot/test/simulation/cache/layers/d651951f-df41-47da-9f89-f0afb6bd274f.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/d651951f-df41-47da-9f89-f0afb6bd274f.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e018fb8380d30b1acd056fdcc4d007f461ddf73c3d8178c996b838640f6aa0e2
-size 45056

--- a/extensions/copilot/test/simulation/cache/layers/d667a7a7-8626-4fdb-937c-e36ae873c0d5.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/d667a7a7-8626-4fdb-937c-e36ae873c0d5.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:361865561dcc2e67ec2c6f972063785d9dbe3d9773a0e9018350157741c43167
-size 4599808

--- a/extensions/copilot/test/simulation/cache/layers/d719ef71-8404-49a4-9f6d-5e9f3118ce51.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/d719ef71-8404-49a4-9f6d-5e9f3118ce51.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55b242581975213acd2c018c0d4acd4c53330a930be943235874229593ae4277
-size 1409024

--- a/extensions/copilot/test/simulation/cache/layers/d9032eab-477d-4bd1-b530-7652ed1e5b70.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/d9032eab-477d-4bd1-b530-7652ed1e5b70.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ae019f89f291cfe2bbe7876e6a04c1f8117e6f179c19ef57486b97fef6c2173
-size 40960

--- a/extensions/copilot/test/simulation/cache/layers/dc4c7b8c-784f-4eb5-9979-c5c6e61ae79c.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/dc4c7b8c-784f-4eb5-9979-c5c6e61ae79c.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e48f76949b5e63d7ce405e069da544c537d655643083e4189cfdbde83ce82405
-size 61440

--- a/extensions/copilot/test/simulation/cache/layers/dcad7537-6f4d-410f-8dbb-ac690963982c.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/dcad7537-6f4d-410f-8dbb-ac690963982c.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f02619415bbb9c64b52f538c8f1efbcaea698672f2349aabcfe55444df290f1
-size 98304

--- a/extensions/copilot/test/simulation/cache/layers/dece6d72-483a-4eba-bfb8-762d7146f5e0.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/dece6d72-483a-4eba-bfb8-762d7146f5e0.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0da9bacdc60825144f6b0ca8a022c7df1d6c1c07442ffc6072662a659c8bf819
-size 28672

--- a/extensions/copilot/test/simulation/cache/layers/e0bdf0eb-0e2c-40e7-9de4-729e9f6e7daa.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/e0bdf0eb-0e2c-40e7-9de4-729e9f6e7daa.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea4e837262c9b95f8a082b5cc90c24c5e138af022b28c2aec03b7e2053c7f77d
-size 35274752

--- a/extensions/copilot/test/simulation/cache/layers/efb8de8c-8109-45e8-9383-789be32852eb.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/efb8de8c-8109-45e8-9383-789be32852eb.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1de7098ba3817dc717aa641087ae7af235cbcef3e7753c550f3080925ec19083
-size 36864

--- a/extensions/copilot/test/simulation/cache/layers/f0da01ab-e2a6-45ac-9673-32b967d14b31.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/f0da01ab-e2a6-45ac-9673-32b967d14b31.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73064b9a8c987b1f514ffec5f19fd7b0edf16b83d883c3debe21e563a341ff28
-size 376832

--- a/extensions/copilot/test/simulation/cache/layers/f245cbe1-2962-48f7-9ce6-41a722693933.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/f245cbe1-2962-48f7-9ce6-41a722693933.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08b360ba96469c60a5e94af1fcfb8117573f47b1222b2a50b86f10fd4242f226
-size 356352

--- a/extensions/copilot/test/simulation/cache/layers/f6f886b2-0933-4a62-91e9-4840cee01850.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/f6f886b2-0933-4a62-91e9-4840cee01850.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:001a83b5c0078ac9d8772359cbbe6ff19dfb910193e72af5359385ebc272dc02
-size 446464

--- a/extensions/copilot/test/simulation/cache/layers/f9bd58e9-8b91-477c-8aad-2222025f4607.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/f9bd58e9-8b91-477c-8aad-2222025f4607.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea2f8fd86172651a201b2da22a4b8c5321386b80b4667a5daea9d42ec119fb16
-size 364544

--- a/extensions/copilot/test/simulation/cache/layers/fa8a1ddb-9625-48c5-ae4f-1d083b1dcb0d.sqlite
+++ b/extensions/copilot/test/simulation/cache/layers/fa8a1ddb-9625-48c5-ae4f-1d083b1dcb0d.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5d6153e354e84272e3de2a1a57d88a1e0c4fb5ac580bf1c011df34beacd80dc
-size 3391488


### PR DESCRIPTION
Descripción
### Resumen
Implementa el sistema de Risk Scoring para PRs descrito en la propuesta. Calcula un score
basado en 4 señales (path, superficie de cambio, historial de fixes, ausencia de tests)
y asigna etiquetas `risk:low` / `risk:medium` / `risk:high` con acciones diferenciadas.

### Archivos

| Archivo | Cambio |
|---------|--------|
| `.github/pr-risk-config.json` | Configuración externalizada: pathScores, thresholds, labels, líneas |
| `.github/workflows/pr-risk-scoring.yml` | Action que se dispara en PRs contra `main` (dry-run por ahora) |
| `build/pr-risk-score.ts` | Script principal con lógica de scoring + gh CLI |
| `build/pr-risk-score.test.ts` | **Nuevo:** 35 tests sintéticos con 6 escenarios integrados |

### Señales de scoring

- **S1 (path)**: max score según capa arquitectónica (vscode-dts=3, electron-main=2, workbench=1, base=0)
- **S2 (superficie)**: umbrales 200/500 líneas + bonus por .d.ts
- **S3 (historial)**: consulta commits de los últimos 90 días en cada archivo (Promise.all + per_page=6)
- **S4 (tests)**: penaliza cambios en src/vs/ sin test acompañante

### Comportamiento por nivel

| Score | Etiqueta | Acciones |
|-------|----------|----------|
| 0–2 | `risk:low` | Solo etiqueta |
| 3–4 | `risk:medium` | Etiqueta + comentario con owners sugeridos |
| 5+ | `risk:high` | Etiqueta + owners + checklist contextual |

### Observaciones
- Los thresholds de score y líneas están en `pr-risk-config.json`
- `DO_APPLY` está en `false`  solo logea resultados. Pasar a `true` para que aplique labels y comments
- Tests: `npx tsx --test build/pr-risk-score.test.ts`