### PR TITLE
feat(pr-prioritizer): add standalone CLI for ranking review-ready ext…

### DIFF
--- a/pr-prioritizer/.gitignore
+++ b/pr-prioritizer/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+data/snapshot-*.json
+report/*.md

--- a/pr-prioritizer/.npmrc
+++ b/pr-prioritizer/.npmrc
@@ -1,0 +1,6 @@
+# Override the root .npmrc which targets Electron headers.
+# This package is a plain Node CLI — no native modules, no Electron.
+runtime=
+target=
+disturl=
+build_from_source=false

--- a/pr-prioritizer/README.md
+++ b/pr-prioritizer/README.md
@@ -1,0 +1,238 @@
+# PR Prioritizer
+
+Standalone CLI that fetches open pull requests for a GitHub repository and
+produces a prioritized Markdown report, ranked by review-readiness.
+
+Implements the prototype described in issue
+[microsoft/vscode#314560](https://github.com/microsoft/vscode/issues/314560).
+
+---
+
+## Prerequisites
+
+| Tool | Minimum version | Check |
+|---|---|---|
+| Node.js | 22.x | `node --version` |
+| npm | 10.x (ships with Node 22) | `npm --version` |
+| Git | any recent version | `git --version` |
+
+No global installs required beyond Node + npm.
+
+---
+
+## Step-by-step: try it from any machine
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/<your-fork>/vscode.git
+cd vscode
+```
+
+If you already have the repo cloned, make sure you're on the right branch:
+
+```bash
+git fetch origin
+git checkout feature/pr-prioritizer
+```
+
+### 2. Enter the tool folder
+
+```bash
+cd pr-prioritizer
+```
+
+All subsequent commands run from inside `pr-prioritizer/`. Do **not** run
+`npm install` at the repo root — that's the VS Code build, not this tool.
+
+### 3. Install dependencies
+
+```bash
+npm install
+```
+
+This installs only two runtime deps (`@octokit/rest`) and two dev deps
+(`tsx`, `typescript`). It does **not** touch the VS Code build.
+
+Expected output:
+```
+added 23 packages, and audited 24 packages in 5s
+found 0 vulnerabilities
+```
+
+### 4. Run the tests
+
+```bash
+npm test
+```
+
+Expected output (66 tests, all passing):
+```
+ℹ tests 66
+ℹ pass  66
+ℹ fail  0
+```
+
+### 5. Generate a sample report (no GitHub token needed)
+
+```bash
+npm run analyze -- --in fixtures/sample-prs.json --out report/demo.md
+```
+
+Then open `report/demo.md` in any Markdown viewer (VS Code Preview, GitHub,
+Obsidian, etc.) to see the ranked report.
+
+Console output:
+```
+Report written to report/demo.md
+  5 ranked | 4 blocked | 1 internal
+```
+
+---
+
+## Step-by-step: fetch real data from GitHub
+
+This step requires a GitHub account and a personal access token.
+
+### 6. Create a GitHub token
+
+1. Go to <https://github.com/settings/tokens> → **Generate new token (classic)**
+2. Select scope: `public_repo` (read-only access to public repositories is enough)
+3. Copy the token (starts with `ghp_…`)
+
+Or use a fine-grained token: **Settings → Developer settings → Fine-grained tokens**,
+grant **Read** access to `Pull requests` on the target repository.
+
+### 7. Set the token in your environment
+
+**Linux / macOS / Git Bash:**
+```bash
+export GITHUB_TOKEN=ghp_yourtoken
+```
+
+**Windows PowerShell:**
+```powershell
+$env:GITHUB_TOKEN = "ghp_yourtoken"
+```
+
+**Windows Command Prompt:**
+```cmd
+set GITHUB_TOKEN=ghp_yourtoken
+```
+
+### 8. Fetch live PRs and generate a report
+
+```bash
+# Fetch (writes data/snapshot-<date>.json)
+npm run fetch -- --repo microsoft/vscode --limit 50
+
+# Analyze the snapshot
+npm run analyze -- --in data/snapshot-2026-01-15.json --out report/report.md --top 25
+```
+
+Or run both steps at once:
+
+```bash
+npm run report -- --repo microsoft/vscode --limit 50
+```
+
+> **Rate limit note:** each PR costs 3 API calls (detail + reviews + files),
+> plus 1 for the listing. At `--limit 50` that is ~151 requests.
+> GitHub's authenticated limit is **5 000 req/hour** — well within range.
+> Without a token the limit is 60 req/hour (enough for ~19 PRs).
+
+---
+
+## All available commands
+
+```
+npm run fetch   -- --repo <owner/repo> [--limit N] [--out path]
+npm run analyze -- [--in path] [--out path] [--top N]
+npm run report  -- --repo <owner/repo> [--limit N] [--out path]
+npm test
+npm run typecheck
+```
+
+| Flag | Command | Default | Description |
+|---|---|---|---|
+| `--repo` | fetch, report | *(required)* | `owner/repo` format |
+| `--limit` | fetch, report | `50` | Max PRs to fetch |
+| `--out` | fetch | `data/snapshot-<date>.json` | Snapshot output path |
+| `--in` | analyze | `fixtures/sample-prs.json` | Snapshot to read |
+| `--out` | analyze, report | `report/report.md` | Report output path |
+| `--top` | analyze | `25` | Max ranked PRs in report |
+
+---
+
+## How the scoring works
+
+Each external PR receives a score out of 100:
+
+| Signal | Max pts | Formula |
+|---|---|---|
+| Age | 30 | `min(ageDays, 90) / 90 × 30` — older = more urgent |
+| Size | 25 | `(1 − min(lines, 1000) / 1000) × 25` — smaller = easier to review |
+| Linked issue | 15 | flat — body contains `closes/fixes/resolves #N` |
+| Tests | 15 | flat — any changed file is a test file, or body mentions "test" |
+| Milestone | 10 | flat — PR is attached to a milestone |
+| Labels | 5 | flat — at least one label is present |
+
+**Hard filters** (excluded from ranking, appear in "Not Ready" section):
+- Draft PRs
+- PRs with `CHANGES_REQUESTED` (latest review per reviewer)
+- PRs with merge conflicts (`mergeable_state: dirty` or `conflicting`)
+
+**External** = `author_association` ∉ `{OWNER, MEMBER, COLLABORATOR}`.
+Internal PRs are excluded from ranking entirely.
+
+### Customizing weights
+
+Edit `WEIGHTS` in [src/score.ts](src/score.ts):
+
+```typescript
+export const WEIGHTS = {
+  age:       30,
+  size:      25,
+  issue:     15,
+  tests:     15,
+  milestone: 10,
+  labels:     5,   // must sum to 100
+};
+```
+
+---
+
+## Project structure
+
+```
+pr-prioritizer/
+  src/
+    types.ts      Snapshot and PR types (shared contract)
+    signals.ts    Pure signal extractors — no I/O, fully testable
+    score.ts      WEIGHTS + pure scoring and ranking logic
+    report.ts     Markdown report builder — no I/O
+    github.ts     GitHub API client (Octokit) — only network code
+    fetch.ts      fetch command — the only module that hits the network
+    cli.ts        Argument parsing and command dispatch
+  test/
+    signals.test.ts   40 cases covering all signal extractors
+    score.test.ts     26 cases covering scoring, filters, ranking order
+  fixtures/
+    sample-prs.json   10 deterministic PRs covering all edge cases
+  data/             Generated snapshots (gitignored, except the fixture)
+  report/           Generated reports (gitignored)
+  RECON.md          Phase 0 repository reconnaissance notes
+```
+
+---
+
+## Isolation from the VS Code build
+
+This package is **fully isolated** from the `microsoft/vscode` root:
+
+- Not listed in any `workspaces` field (the root doesn't use npm workspaces)
+- Has its own `.npmrc` that overrides the root's Electron-targeting settings
+- Not referenced by any root `tsconfig.json` or `eslint.config.js`
+- `npm install` / `npm test` at the repo root has zero effect on this package
+
+See [RECON.md](RECON.md) for the full reconnaissance findings.

--- a/pr-prioritizer/RECON.md
+++ b/pr-prioritizer/RECON.md
@@ -1,0 +1,79 @@
+# Phase 0 — Reconnaissance
+
+> Explored before writing any implementation code.
+
+---
+
+## 1. Node, package manager, workspaces
+
+| Item | Finding |
+|---|---|
+| **Node version** | `22.22.1` (from `.nvmrc` at repo root) |
+| **Package manager** | `npm` — `package-lock.json` present, no `packageManager` field, no `.yarnrc`/`.pnpmrc` |
+| **npm workspaces** | **NOT used** — root `package.json` has no `workspaces` field |
+
+**Root `.npmrc` caveat:** The root `.npmrc` targets Electron's runtime (`runtime="electron"`, `target="39.8.8"`, `disturl="https://electronjs.org/headers"`). This means `npm install` at the repo root compiles native modules against Electron headers, not Node. Our isolated `pr-prioritizer/package.json` must ship its own clean `.npmrc` that opts out of these electron settings; otherwise any `npm install` run inside our subfolder that inherits the parent `.npmrc` could try to compile native deps against Electron and fail.
+
+**Decision:** `pr-prioritizer/` ships an `.npmrc` with `runtime=` unset (overrides the parent). No workspace registration needed because the root never had workspaces to begin with.
+
+---
+
+## 2. Config to respect (or not collide with)
+
+### TypeScript
+- Root has no single `tsconfig.json`; individual projects have their own (e.g., `build/tsconfig.json`, `src/tsconfig.json`).
+- `build/tsconfig.json` pattern: `"strict": true`, `"target": "es2024"`, `"module": "nodenext"`, `"noEmit": true`, `"noUnusedLocals": true`, `"noUnusedParameters": true`, `"verbatimModuleSyntax": true`.
+- Our `tsconfig.json` follows this pattern but **emits** (`noEmit: false`) to `dist/` because we need runnable JS output.
+
+### ESLint
+- Root uses **flat config** (`eslint.config.js`) with a custom in-tree plugin (`.eslint-plugin-local/`) and a Microsoft copyright header rule.
+- `npm run eslint` runs `build/eslint.ts` which internally constructs paths — it likely targets `src/`, `build/`, `extensions/`. It does **not** automatically sweep every subfolder.
+- `.eslint-ignore` does not mention `pr-prioritizer/`, but the flat config's path targeting means our folder is excluded by default.
+- **Risk:** if someone runs `eslint pr-prioritizer/` explicitly, the Microsoft header rule would fire. Not a problem for isolated dev, but noted.
+
+### Formatting
+- `tsfmt.json` at root: **tabs** (tabSize 4, `convertTabsToSpaces: false`), no Prettier.
+- Our code follows the same convention: tabs for indentation.
+
+---
+
+## 3. Test framework and standalone tooling
+
+| Item | Finding |
+|---|---|
+| Root test runner | `mocha` (`test-node` script uses mocha with `--ui=tdd`) |
+| Build test runner | `cd build && npm run test` (build has its own package.json) |
+| Smoke / browser | Playwright-based |
+| `node:test` usage | Not used at root, but Node 22 ships it natively — safe to use in our isolated package |
+
+Standalone tooling in `build/` and `scripts/` is all **VS Code infrastructure** (gulp tasks, hygiene checkers, electron launchers). None of it is a natural home for an external-PR analysis tool.
+
+**Chosen test runner for `pr-prioritizer/`:** `node:test` + `tsx` (Node 22 built-in, zero extra test-framework deps, pairs cleanly with `tsx` for on-the-fly TypeScript execution).
+
+---
+
+## 4. Alignment check: does `pr-prioritizer/` as an isolated folder fit?
+
+**Yes — cleanly.** Rationale:
+
+1. **No workspace collision:** the root never registered workspaces, so a new `package.json` in a subfolder is invisible to `npm install` at the root. No `--ignore-workspace-root-check` hacks needed.
+2. **No tsconfig collision:** VS Code's root tsconfig covers `src/`, `build/`, etc. Our own `tsconfig.json` is fully self-contained and never referenced by any root config.
+3. **No eslint collision:** the root flat-config doesn't glob into arbitrary subfolders; our folder won't be linted unless someone explicitly points eslint at it.
+4. **No build collision:** the gulpfile never references arbitrary top-level subdirectories; our folder is invisible to `npm run compile`.
+5. **One potential gotcha:** the root `.npmrc` (Electron headers). Mitigated by shipping our own `.npmrc` that resets `runtime` and `target`.
+
+**No conflicts detected with the plan from the issue. Proceeding with implementation.**
+
+---
+
+## Decision: folder location
+
+```
+pr-prioritizer/   ← top-level, isolated, self-contained
+  .npmrc          ← resets runtime/target away from Electron
+  package.json    ← its own deps, scripts, NOT a workspace member
+  tsconfig.json   ← strict, ES2022, nodenext, emits to dist/
+  ...
+```
+
+This mirrors how other self-contained tooling lives at the top level of large mono-repos (e.g., `test/smoke/`, `build/`) — each with their own `package.json` and `node_modules`.

--- a/pr-prioritizer/fixtures/sample-prs.json
+++ b/pr-prioritizer/fixtures/sample-prs.json
@@ -1,0 +1,218 @@
+{
+	"repo": "microsoft/vscode",
+	"fetched_at": "2026-01-15T12:00:00.000Z",
+	"total_open": 10,
+	"prs": [
+		{
+			"number": 100,
+			"title": "Fix: editor cursor blink on retina displays",
+			"url": "https://github.com/microsoft/vscode/pull/100",
+			"author": "external-alice",
+			"author_association": "CONTRIBUTOR",
+			"created_at": "2025-10-17T12:00:00.000Z",
+			"draft": false,
+			"mergeable_state": "clean",
+			"additions": 45,
+			"deletions": 12,
+			"changed_files": 3,
+			"labels": ["bug"],
+			"milestone": "November 2025",
+			"body": "Fixes #88 by adjusting the blink interval for retina displays.\n\nTested on macOS 14 with VSCode dev build.",
+			"reviews": [
+				{ "state": "APPROVED", "user": { "login": "maintainer-bob" }, "submitted_at": "2025-10-20T10:00:00.000Z" }
+			],
+			"files": [
+				{ "filename": "src/vs/editor/browser/viewParts/cursor/cursor.ts" },
+				{ "filename": "src/vs/editor/browser/viewParts/cursor/cursor.test.ts" },
+				{ "filename": "src/vs/editor/test/browser/cursor.test.ts" }
+			]
+		},
+		{
+			"number": 101,
+			"title": "Add keyboard shortcut to toggle minimap",
+			"url": "https://github.com/microsoft/vscode/pull/101",
+			"author": "external-carlos",
+			"author_association": "FIRST_TIME_CONTRIBUTOR",
+			"created_at": "2025-07-01T08:00:00.000Z",
+			"draft": false,
+			"mergeable_state": "clean",
+			"additions": 10,
+			"deletions": 2,
+			"changed_files": 2,
+			"labels": ["feature-request", "good first issue"],
+			"milestone": null,
+			"body": "Resolves #42.\n\nAdds a new keybinding workbench.action.toggleMinimap.",
+			"reviews": [],
+			"files": [
+				{ "filename": "src/vs/workbench/contrib/minimap/browser/minimapActions.ts" },
+				{ "filename": "package.json" }
+			]
+		},
+		{
+			"number": 102,
+			"title": "WIP: Refactor terminal renderer",
+			"url": "https://github.com/microsoft/vscode/pull/102",
+			"author": "external-diana",
+			"author_association": "NONE",
+			"created_at": "2026-01-10T09:00:00.000Z",
+			"draft": true,
+			"mergeable_state": "clean",
+			"additions": 800,
+			"deletions": 600,
+			"changed_files": 20,
+			"labels": [],
+			"milestone": null,
+			"body": "Work in progress — do not review yet.",
+			"reviews": [],
+			"files": [
+				{ "filename": "src/vs/workbench/contrib/terminal/browser/terminalRenderer.ts" }
+			]
+		},
+		{
+			"number": 103,
+			"title": "Fix typo in README",
+			"url": "https://github.com/microsoft/vscode/pull/103",
+			"author": "external-eve",
+			"author_association": "CONTRIBUTOR",
+			"created_at": "2025-12-01T10:00:00.000Z",
+			"draft": false,
+			"mergeable_state": "dirty",
+			"additions": 1,
+			"deletions": 1,
+			"changed_files": 1,
+			"labels": ["documentation"],
+			"milestone": null,
+			"body": "Fixes a typo in the contributing guide.",
+			"reviews": [],
+			"files": [
+				{ "filename": "CONTRIBUTING.md" }
+			]
+		},
+		{
+			"number": 104,
+			"title": "Improve extension host startup telemetry",
+			"url": "https://github.com/microsoft/vscode/pull/104",
+			"author": "internal-frank",
+			"author_association": "MEMBER",
+			"created_at": "2025-11-01T10:00:00.000Z",
+			"draft": false,
+			"mergeable_state": "clean",
+			"additions": 200,
+			"deletions": 50,
+			"changed_files": 8,
+			"labels": ["telemetry"],
+			"milestone": "November 2025",
+			"body": "Improves telemetry for extension host startup.",
+			"reviews": [],
+			"files": [
+				{ "filename": "src/vs/workbench/services/extensions/node/extensionHostProcessManager.ts" }
+			]
+		},
+		{
+			"number": 105,
+			"title": "Add support for multi-cursor paste",
+			"url": "https://github.com/microsoft/vscode/pull/105",
+			"author": "external-grace",
+			"author_association": "CONTRIBUTOR",
+			"created_at": "2025-09-01T08:00:00.000Z",
+			"draft": false,
+			"mergeable_state": "clean",
+			"additions": 300,
+			"deletions": 100,
+			"changed_files": 5,
+			"labels": ["editor-core"],
+			"milestone": "October 2025",
+			"body": "Closes #55.\n\nThis PR adds multi-cursor paste behaviour matching the user's expectation.",
+			"reviews": [
+				{ "state": "CHANGES_REQUESTED", "user": { "login": "maintainer-bob" }, "submitted_at": "2025-09-10T10:00:00.000Z" }
+			],
+			"files": [
+				{ "filename": "src/vs/editor/contrib/multicursor/browser/multicursor.ts" },
+				{ "filename": "src/vs/editor/contrib/multicursor/test/browser/multicursor.test.ts" }
+			]
+		},
+		{
+			"number": 106,
+			"title": "Improve settings search ranking",
+			"url": "https://github.com/microsoft/vscode/pull/106",
+			"author": "external-henry",
+			"author_association": "NONE",
+			"created_at": "2025-06-01T10:00:00.000Z",
+			"draft": false,
+			"mergeable_state": "clean",
+			"additions": 80,
+			"deletions": 30,
+			"changed_files": 4,
+			"labels": ["settings"],
+			"milestone": "July 2025",
+			"body": "Improves the ranking algorithm for settings search.\n\nSee also issue #77.",
+			"reviews": [],
+			"files": [
+				{ "filename": "src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts" },
+				{ "filename": "src/vs/workbench/contrib/preferences/test/browser/settingsEditor2.test.ts" }
+			]
+		},
+		{
+			"number": 107,
+			"title": "Add dark mode for walkthrough pages",
+			"url": "https://github.com/microsoft/vscode/pull/107",
+			"author": "external-iris",
+			"author_association": "FIRST_TIME_CONTRIBUTOR",
+			"created_at": "2026-01-14T10:00:00.000Z",
+			"draft": false,
+			"mergeable_state": "clean",
+			"additions": 5,
+			"deletions": 2,
+			"changed_files": 1,
+			"labels": [],
+			"milestone": null,
+			"body": "Small styling fix for walkthrough pages in dark mode.",
+			"reviews": [],
+			"files": [
+				{ "filename": "src/vs/workbench/contrib/walkThrough/browser/walkThrough.css" }
+			]
+		},
+		{
+			"number": 108,
+			"title": "Fix search panel not closing on Escape",
+			"url": "https://github.com/microsoft/vscode/pull/108",
+			"author": "external-jake",
+			"author_association": "CONTRIBUTOR",
+			"created_at": "2025-11-20T10:00:00.000Z",
+			"draft": false,
+			"mergeable_state": "conflicting",
+			"additions": 15,
+			"deletions": 5,
+			"changed_files": 2,
+			"labels": ["bug"],
+			"milestone": null,
+			"body": "Fixes #99 where pressing Escape in the search panel does not close it.",
+			"reviews": [],
+			"files": [
+				{ "filename": "src/vs/workbench/contrib/search/browser/searchPanel.ts" }
+			]
+		},
+		{
+			"number": 109,
+			"title": "Remove deprecated API usages in git extension",
+			"url": "https://github.com/microsoft/vscode/pull/109",
+			"author": "external-kate",
+			"author_association": "CONTRIBUTOR",
+			"created_at": "2025-08-01T10:00:00.000Z",
+			"draft": false,
+			"mergeable_state": "clean",
+			"additions": 120,
+			"deletions": 200,
+			"changed_files": 10,
+			"labels": ["git", "refactor"],
+			"milestone": "September 2025",
+			"body": "Resolves #33.\n\nRemoves deprecated API usage and adds spec coverage.",
+			"reviews": [],
+			"files": [
+				{ "filename": "extensions/git/src/api/api1.ts" },
+				{ "filename": "extensions/git/src/repository.ts" },
+				{ "filename": "extensions/git/src/test/git.test.ts" }
+			]
+		}
+	]
+}

--- a/pr-prioritizer/package-lock.json
+++ b/pr-prioritizer/package-lock.json
@@ -1,0 +1,760 @@
+{
+	"name": "pr-prioritizer",
+	"version": "0.1.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "pr-prioritizer",
+			"version": "0.1.0",
+			"dependencies": {
+				"@octokit/rest": "^20.1.2"
+			},
+			"devDependencies": {
+				"@types/node": "^22.10.7",
+				"tsx": "^4.19.2",
+				"typescript": "^5.7.3"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+			"integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+			"integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+			"integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+			"integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+			"integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+			"integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+			"integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+			"integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+			"integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+			"integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+			"integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+			"integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+			"integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+			"integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+			"integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+			"integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+			"integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+			"integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+			"integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+			"integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+			"integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+			"integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+			"integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@octokit/auth-token": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-token": "^4.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.4.1",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.0.0",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+			"integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^8.4.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "11.4.4-cjs.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+			"integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.7.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-request-log": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+			"integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "13.3.2-cjs.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+			"integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.8.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^5"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+			"integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^9.0.6",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/rest": {
+			"version": "20.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+			"integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/core": "^5.0.2",
+				"@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+				"@octokit/plugin-request-log": "^4.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "22.19.20",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+			"integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/before-after-hook": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+			"license": "ISC"
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+			"integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.0",
+				"@esbuild/android-arm": "0.28.0",
+				"@esbuild/android-arm64": "0.28.0",
+				"@esbuild/android-x64": "0.28.0",
+				"@esbuild/darwin-arm64": "0.28.0",
+				"@esbuild/darwin-x64": "0.28.0",
+				"@esbuild/freebsd-arm64": "0.28.0",
+				"@esbuild/freebsd-x64": "0.28.0",
+				"@esbuild/linux-arm": "0.28.0",
+				"@esbuild/linux-arm64": "0.28.0",
+				"@esbuild/linux-ia32": "0.28.0",
+				"@esbuild/linux-loong64": "0.28.0",
+				"@esbuild/linux-mips64el": "0.28.0",
+				"@esbuild/linux-ppc64": "0.28.0",
+				"@esbuild/linux-riscv64": "0.28.0",
+				"@esbuild/linux-s390x": "0.28.0",
+				"@esbuild/linux-x64": "0.28.0",
+				"@esbuild/netbsd-arm64": "0.28.0",
+				"@esbuild/netbsd-x64": "0.28.0",
+				"@esbuild/openbsd-arm64": "0.28.0",
+				"@esbuild/openbsd-x64": "0.28.0",
+				"@esbuild/openharmony-arm64": "0.28.0",
+				"@esbuild/sunos-x64": "0.28.0",
+				"@esbuild/win32-arm64": "0.28.0",
+				"@esbuild/win32-ia32": "0.28.0",
+				"@esbuild/win32-x64": "0.28.0"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/tsx": {
+			"version": "4.22.4",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+			"integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.28.0"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/universal-user-agent": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+			"license": "ISC"
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		}
+	}
+}

--- a/pr-prioritizer/package.json
+++ b/pr-prioritizer/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "pr-prioritizer",
+	"version": "0.1.0",
+	"description": "Offline-capable CLI that scores and ranks review-ready external PRs for microsoft/vscode",
+	"private": true,
+	"type": "module",
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"scripts": {
+		"build": "tsc --project tsconfig.json",
+		"fetch": "tsx src/cli.ts fetch",
+		"analyze": "tsx src/cli.ts analyze",
+		"report": "tsx src/cli.ts report",
+		"test": "node --import tsx/esm --test test/signals.test.ts test/score.test.ts",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@octokit/rest": "^20.1.2"
+	},
+	"devDependencies": {
+		"tsx": "^4.19.2",
+		"typescript": "^5.7.3",
+		"@types/node": "^22.10.7"
+	}
+}

--- a/pr-prioritizer/src/cli.ts
+++ b/pr-prioritizer/src/cli.ts
@@ -1,0 +1,107 @@
+/**
+ * CLI entry point — parses arguments and dispatches to fetch or analyze.
+ *
+ * Usage:
+ *   tsx src/cli.ts fetch   --repo microsoft/vscode --limit 50 --out data/snapshot.json
+ *   tsx src/cli.ts analyze --in data/snapshot.json  --out report/report.md  --top 25
+ *   tsx src/cli.ts report  --repo microsoft/vscode --limit 50 --out report/report.md
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type { Snapshot } from './types.js';
+import { runFetch } from './fetch.js';
+import { scorePRs } from './score.js';
+import { buildReport } from './report.js';
+
+/** Minimal flag parser — keeps zero extra deps */
+function parseArgs(argv: string[]): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i].startsWith('--')) {
+			const key = argv[i].slice(2);
+			const next = argv[i + 1];
+			if (next !== undefined && !next.startsWith('--')) {
+				result[key] = next;
+				i++;
+			} else {
+				result[key] = 'true';
+			}
+		}
+	}
+	return result;
+}
+
+function requireFlag(flags: Record<string, string>, name: string): string {
+	const v = flags[name];
+	if (!v) { throw new Error(`Missing required flag --${name}`); }
+	return v;
+}
+
+async function cmdFetch(flags: Record<string, string>): Promise<void> {
+	const token = process.env['GITHUB_TOKEN'] ?? '';
+	if (!token) {
+		console.warn('Warning: GITHUB_TOKEN not set. Rate limit will be very low (60 req/hour).');
+	}
+	await runFetch({
+		repo: requireFlag(flags, 'repo'),
+		limit: parseInt(flags['limit'] ?? '50', 10),
+		out: flags['out'] ?? `data/snapshot-${new Date().toISOString().slice(0, 10)}.json`,
+		token,
+	});
+}
+
+function cmdAnalyze(flags: Record<string, string>): void {
+	const inFile = flags['in'] ?? 'fixtures/sample-prs.json';
+	const outFile = flags['out'] ?? 'report/report.md';
+	const top = parseInt(flags['top'] ?? '25', 10);
+
+	if (!fs.existsSync(inFile)) {
+		throw new Error(`Snapshot file not found: ${inFile}`);
+	}
+
+	const snapshot: Snapshot = JSON.parse(fs.readFileSync(inFile, 'utf8'));
+	const { ranked, filtered, internal } = scorePRs(snapshot.prs);
+	const report = buildReport(snapshot, ranked, filtered, internal, { top });
+
+	const outDir = path.dirname(outFile);
+	if (outDir && !fs.existsSync(outDir)) {
+		fs.mkdirSync(outDir, { recursive: true });
+	}
+	fs.writeFileSync(outFile, report, 'utf8');
+
+	console.log(`Report written to ${outFile}`);
+	console.log(`  ${ranked.length} ranked | ${filtered.length} blocked | ${internal.length} internal`);
+}
+
+async function cmdReport(flags: Record<string, string>): Promise<void> {
+	const snapshotPath = `data/snapshot-${new Date().toISOString().slice(0, 10)}.json`;
+	await cmdFetch({ ...flags, out: flags['out-snapshot'] ?? snapshotPath });
+	cmdAnalyze({ ...flags, in: snapshotPath });
+}
+
+async function main(): Promise<void> {
+	const [, , command, ...rest] = process.argv;
+	const flags = parseArgs(rest);
+
+	switch (command) {
+		case 'fetch':
+			await cmdFetch(flags);
+			break;
+		case 'analyze':
+			cmdAnalyze(flags);
+			break;
+		case 'report':
+			await cmdReport(flags);
+			break;
+		default:
+			console.error(`Unknown command: ${command ?? '(none)'}`);
+			console.error('Usage: tsx src/cli.ts <fetch|analyze|report> [flags]');
+			process.exit(1);
+	}
+}
+
+main().catch(err => {
+	console.error(err instanceof Error ? err.message : String(err));
+	process.exit(1);
+});

--- a/pr-prioritizer/src/cli.ts
+++ b/pr-prioritizer/src/cli.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 /**
  * CLI entry point — parses arguments and dispatches to fetch or analyze.
  *

--- a/pr-prioritizer/src/fetch.ts
+++ b/pr-prioritizer/src/fetch.ts
@@ -1,0 +1,69 @@
+/**
+ * Fetch command — hits the GitHub API and writes a snapshot JSON to disk.
+ * This is the ONLY module that performs network I/O.
+ * `analyze` never calls this module; it reads the snapshot directly.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type { Snapshot } from './types.js';
+import {
+	createClient,
+	parseRepo,
+	listOpenPRs,
+	getPRDetail,
+	getPRReviews,
+	getPRFiles,
+	normalizePR,
+} from './github.js';
+
+export interface FetchOptions {
+	repo: string;
+	limit: number;
+	out: string;
+	token: string;
+}
+
+export async function runFetch(opts: FetchOptions): Promise<void> {
+	const { owner, repo } = parseRepo(opts.repo);
+	const client = createClient(opts.token);
+
+	console.log(`Fetching open PRs for ${opts.repo} (limit: ${opts.limit})…`);
+
+	// Step 1: list open PRs
+	const rawList = await listOpenPRs(client, owner, repo, opts.limit);
+	console.log(`  Found ${rawList.length} PRs in listing.`);
+
+	// Step 2: for each PR, fetch detail + reviews + files (N+1 — see github.ts)
+	const normalized = [];
+	for (let i = 0; i < rawList.length; i++) {
+		const listItem = rawList[i];
+		const n = listItem.number;
+		process.stdout.write(`  [${i + 1}/${rawList.length}] #${n} ${listItem.title.slice(0, 50)}…\r`);
+
+		const [detail, reviews, files] = await Promise.all([
+			getPRDetail(client, owner, repo, n),
+			getPRReviews(client, owner, repo, n),
+			getPRFiles(client, owner, repo, n),
+		]);
+
+		normalized.push(normalizePR(listItem, detail, reviews, files));
+	}
+	process.stdout.write('\n');
+
+	// Step 3: build snapshot
+	const snapshot: Snapshot = {
+		repo: opts.repo,
+		fetched_at: new Date().toISOString(),
+		total_open: rawList.length,
+		prs: normalized,
+	};
+
+	// Step 4: write to disk
+	const outDir = path.dirname(opts.out);
+	if (outDir && !fs.existsSync(outDir)) {
+		fs.mkdirSync(outDir, { recursive: true });
+	}
+	fs.writeFileSync(opts.out, JSON.stringify(snapshot, null, 2), 'utf8');
+	console.log(`Snapshot written to ${opts.out}`);
+}

--- a/pr-prioritizer/src/fetch.ts
+++ b/pr-prioritizer/src/fetch.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 /**
  * Fetch command — hits the GitHub API and writes a snapshot JSON to disk.
  * This is the ONLY module that performs network I/O.

--- a/pr-prioritizer/src/github.ts
+++ b/pr-prioritizer/src/github.ts
@@ -1,0 +1,125 @@
+/**
+ * GitHub API client — thin wrapper around @octokit/rest.
+ * All network calls live here; the rest of the codebase is offline-capable.
+ */
+
+import { Octokit } from '@octokit/rest';
+import type { NormalizedPR, RawReview, RawFile } from './types.js';
+
+export function createClient(token: string): Octokit {
+	return new Octokit({ auth: token });
+}
+
+/**
+ * List the first `perPage` open PRs for a repo (page 1 only).
+ * Returns raw API objects — normalization happens in fetch.ts.
+ */
+export async function listOpenPRs(
+	client: Octokit,
+	owner: string,
+	repo: string,
+	perPage: number,
+): Promise<Awaited<ReturnType<Octokit['rest']['pulls']['list']>>['data']> {
+	const { data } = await client.rest.pulls.list({
+		owner,
+		repo,
+		state: 'open',
+		per_page: perPage,
+		sort: 'created',
+		direction: 'asc',
+	});
+	return data;
+}
+
+/**
+ * Fetch the full PR detail for a single PR number.
+ * Provides additions, deletions, changed_files, mergeable_state.
+ */
+export async function getPRDetail(
+	client: Octokit,
+	owner: string,
+	repo: string,
+	pull_number: number,
+): Promise<Awaited<ReturnType<Octokit['rest']['pulls']['get']>>['data']> {
+	const { data } = await client.rest.pulls.get({ owner, repo, pull_number });
+	return data;
+}
+
+/**
+ * Fetch all reviews for a PR.
+ *
+ * NOTE — N+1 pattern: we call this once per PR, meaning `limit` PRs = `limit`
+ * extra API requests. At the default limit of 50 that costs 50 review calls +
+ * 50 file calls + 1 list call = 101 requests total. GitHub's unauthenticated
+ * rate limit is 60 req/hour; authenticated is 5000 req/hour. Always use a
+ * token (GITHUB_TOKEN env var) or this will fail for any non-trivial limit.
+ */
+export async function getPRReviews(
+	client: Octokit,
+	owner: string,
+	repo: string,
+	pull_number: number,
+): Promise<RawReview[]> {
+	const { data } = await client.rest.pulls.listReviews({ owner, repo, pull_number });
+	return data.map(r => ({
+		state: r.state as RawReview['state'],
+		user: r.user ? { login: r.user.login } : null,
+		submitted_at: r.submitted_at ?? null,
+	}));
+}
+
+/**
+ * Fetch the list of files changed by a PR (up to 3000 — GitHub API cap).
+ */
+export async function getPRFiles(
+	client: Octokit,
+	owner: string,
+	repo: string,
+	pull_number: number,
+): Promise<RawFile[]> {
+	const { data } = await client.rest.pulls.listFiles({
+		owner,
+		repo,
+		pull_number,
+		per_page: 100,
+	});
+	return data.map(f => ({ filename: f.filename }));
+}
+
+/** Parse "owner/repo" string into { owner, repo } */
+export function parseRepo(repoArg: string): { owner: string; repo: string } {
+	const parts = repoArg.split('/');
+	if (parts.length !== 2 || !parts[0] || !parts[1]) {
+		throw new Error(`Invalid repo format "${repoArg}". Expected "owner/repo".`);
+	}
+	return { owner: parts[0], repo: parts[1] };
+}
+
+/**
+ * Normalize a raw PR list item + detail + reviews + files into a NormalizedPR.
+ */
+export function normalizePR(
+	list: Awaited<ReturnType<Octokit['rest']['pulls']['list']>>['data'][number],
+	detail: Awaited<ReturnType<Octokit['rest']['pulls']['get']>>['data'],
+	reviews: RawReview[],
+	files: RawFile[],
+): NormalizedPR {
+	return {
+		number: list.number,
+		title: list.title,
+		url: list.html_url,
+		author: list.user?.login ?? 'unknown',
+		author_association: list.author_association as NormalizedPR['author_association'],
+		created_at: list.created_at,
+		draft: list.draft ?? false,
+		mergeable_state: detail.mergeable_state ?? 'unknown',
+		additions: detail.additions,
+		deletions: detail.deletions,
+		changed_files: detail.changed_files,
+		labels: list.labels.map(l => (typeof l === 'string' ? l : (l.name ?? ''))).filter(Boolean),
+		milestone: list.milestone?.title ?? null,
+		body: list.body ?? '',
+		reviews,
+		files,
+	};
+}

--- a/pr-prioritizer/src/github.ts
+++ b/pr-prioritizer/src/github.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 /**
  * GitHub API client — thin wrapper around @octokit/rest.
  * All network calls live here; the rest of the codebase is offline-capable.

--- a/pr-prioritizer/src/report.ts
+++ b/pr-prioritizer/src/report.ts
@@ -1,0 +1,196 @@
+/**
+ * Markdown report builder — pure function, no I/O.
+ * Takes the output of scorePRs() and produces a formatted Markdown string.
+ */
+
+import type { NormalizedPR, Snapshot } from './types.js';
+import type { RankedPR, FilteredPR } from './score.js';
+import { WEIGHTS } from './score.js';
+
+export interface ReportOptions {
+	/** Maximum ranked PRs to include in the main table (default: 25) */
+	top?: number;
+}
+
+function mdLink(text: string, url: string): string {
+	return `[${text}](${url})`;
+}
+
+function row(...cells: string[]): string {
+	return '| ' + cells.join(' | ') + ' |';
+}
+
+function separator(widths: number[]): string {
+	return '| ' + widths.map(w => '-'.repeat(w)).join(' | ') + ' |';
+}
+
+function fmtScore(n: number): string {
+	return n.toFixed(1);
+}
+
+function fmtLabels(labels: string[]): string {
+	if (labels.length === 0) { return '—'; }
+	return labels.map(l => `\`${l}\``).join(' ');
+}
+
+/** Render the prioritized ranking table */
+function renderRanked(ranked: RankedPR[], top: number): string {
+	const visible = ranked.slice(0, top);
+	if (visible.length === 0) {
+		return '_No external PRs ready for review._\n';
+	}
+
+	const headers = ['Rank', 'PR', 'Author', 'Age (d)', 'Size', 'Tests', 'Issue', 'Milestone', 'Labels', 'Score'];
+	const lines: string[] = [
+		row(...headers),
+		separator([4, 40, 20, 7, 5, 5, 5, 20, 30, 5]),
+	];
+
+	for (let i = 0; i < visible.length; i++) {
+		const { pr, signals, breakdown } = visible[i];
+		lines.push(row(
+			String(i + 1),
+			mdLink(`#${pr.number} ${pr.title.slice(0, 60)}`, pr.url),
+			`@${pr.author}`,
+			String(signals.ageDays),
+			`${signals.sizeBucket} (${signals.size})`,
+			signals.hasTests ? 'yes' : 'no',
+			signals.linkedIssues.length > 0 ? signals.linkedIssues.map(n => `#${n}`).join(', ') : '—',
+			signals.milestone ?? '—',
+			fmtLabels(signals.labels),
+			fmtScore(breakdown.total),
+		));
+	}
+
+	return lines.join('\n') + '\n';
+}
+
+/** Render the score breakdown table for ranked PRs */
+function renderBreakdown(ranked: RankedPR[], top: number): string {
+	const visible = ranked.slice(0, top);
+	if (visible.length === 0) { return ''; }
+
+	const headers = ['PR', 'Age pts', 'Size pts', 'Issue pts', 'Tests pts', 'Milestone pts', 'Labels pts', 'Total'];
+	const lines: string[] = [
+		row(...headers),
+		separator([10, 7, 8, 9, 9, 13, 10, 5]),
+	];
+
+	for (const { pr, breakdown } of visible) {
+		lines.push(row(
+			`#${pr.number}`,
+			fmtScore(breakdown.age),
+			fmtScore(breakdown.size),
+			fmtScore(breakdown.issue),
+			fmtScore(breakdown.tests),
+			fmtScore(breakdown.milestone),
+			fmtScore(breakdown.labels),
+			fmtScore(breakdown.total),
+		));
+	}
+
+	return lines.join('\n') + '\n';
+}
+
+/** Render the "not ready / blocked" section */
+function renderFiltered(filtered: FilteredPR[]): string {
+	if (filtered.length === 0) {
+		return '_None._\n';
+	}
+
+	const headers = ['PR', 'Author', 'Reason'];
+	const lines: string[] = [
+		row(...headers),
+		separator([10, 20, 30]),
+	];
+
+	for (const { pr, reason } of filtered) {
+		lines.push(row(
+			mdLink(`#${pr.number}`, pr.url),
+			`@${pr.author}`,
+			reason,
+		));
+	}
+
+	return lines.join('\n') + '\n';
+}
+
+/** Render the methodology footnote */
+function renderMethodology(): string {
+	const entries = [
+		`- **Age (max ${WEIGHTS.age} pts):** \`min(ageDays, 90) / 90 × ${WEIGHTS.age}\` — rewards long-waiting PRs, capped at 90 days`,
+		`- **Size (max ${WEIGHTS.size} pts):** \`(1 − min(additions+deletions, 1000) / 1000) × ${WEIGHTS.size}\` — rewards small, reviewable PRs`,
+		`- **Issue (${WEIGHTS.issue} pts flat):** linked closing keyword (\`closes/fixes/resolves #N\`) present in the body`,
+		`- **Tests (${WEIGHTS.tests} pts flat):** any changed file matches \`.test.\`/\`.spec.\`/\`test(s)/\` pattern, or body mentions "test"`,
+		`- **Milestone (${WEIGHTS.milestone} pts flat):** PR is attached to a milestone`,
+		`- **Labels (${WEIGHTS.labels} pts flat):** at least one label is present (indicates triage happened)`,
+		``,
+		`**Hard filters (excluded from ranking):**`,
+		`- Draft PRs`,
+		`- PRs with an open \`CHANGES_REQUESTED\` review (per reviewer, latest wins)`,
+		`- PRs with \`mergeable_state\` of \`dirty\` or \`conflicting\``,
+		``,
+		`**External definition:** author \`author_association\` ∉ \`{OWNER, MEMBER, COLLABORATOR}\``,
+	];
+
+	return entries.join('\n') + '\n';
+}
+
+/**
+ * Build the complete Markdown report string.
+ *
+ * @param snapshot  The source snapshot (for repo, date, total_open)
+ * @param ranked    Sorted ranked PRs from scorePRs()
+ * @param filtered  Blocked/draft PRs from scorePRs()
+ * @param internal  Internal-author PRs (excluded from ranking)
+ * @param opts      Display options (top N)
+ */
+export function buildReport(
+	snapshot: Snapshot,
+	ranked: RankedPR[],
+	filtered: FilteredPR[],
+	internal: NormalizedPR[],
+	opts: ReportOptions = {},
+): string {
+	const top = opts.top ?? 25;
+	const lines: string[] = [];
+
+	// Header
+	lines.push(`# PR Prioritizer Report`);
+	lines.push(``);
+	lines.push(`| Field | Value |`);
+	lines.push(`| --- | --- |`);
+	lines.push(`| Repo | ${snapshot.repo} |`);
+	lines.push(`| Snapshot date | ${snapshot.fetched_at} |`);
+	lines.push(`| Report generated | ${new Date().toISOString()} |`);
+	lines.push(`| Open PRs in snapshot | ${snapshot.total_open} |`);
+	lines.push(`| External PRs | ${ranked.length + filtered.length} |`);
+	lines.push(`| Ready for review | ${ranked.length} |`);
+	lines.push(`| Blocked / draft | ${filtered.length} |`);
+	lines.push(`| Internal (excluded) | ${internal.length} |`);
+	lines.push(``);
+
+	// Ranked table
+	lines.push(`## Ready for Review (top ${Math.min(top, ranked.length)} of ${ranked.length})`);
+	lines.push(``);
+	lines.push(renderRanked(ranked, top));
+
+	// Breakdown
+	lines.push(`### Score Breakdown`);
+	lines.push(``);
+	lines.push(renderBreakdown(ranked, top));
+
+	// Filtered / blocked
+	lines.push(`## Not Ready / Blocked`);
+	lines.push(``);
+	lines.push(renderFiltered(filtered));
+
+	// Methodology
+	lines.push(`---`);
+	lines.push(``);
+	lines.push(`## Methodology`);
+	lines.push(``);
+	lines.push(renderMethodology());
+
+	return lines.join('\n');
+}

--- a/pr-prioritizer/src/report.ts
+++ b/pr-prioritizer/src/report.ts
@@ -1,11 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 /**
  * Markdown report builder — pure function, no I/O.
  * Takes the output of scorePRs() and produces a formatted Markdown string.
  */
 
 import type { NormalizedPR, Snapshot } from './types.js';
-import type { RankedPR, FilteredPR } from './score.js';
-import { WEIGHTS } from './score.js';
+import { WEIGHTS, type RankedPR, type FilteredPR } from './score.js';
 
 export interface ReportOptions {
 	/** Maximum ranked PRs to include in the main table (default: 25) */

--- a/pr-prioritizer/src/score.ts
+++ b/pr-prioritizer/src/score.ts
@@ -1,0 +1,157 @@
+/**
+ * Scoring engine — pure functions, no I/O.
+ *
+ * Design rationale:
+ *   - All weights live in a single exported `WEIGHTS` constant so they can be
+ *     overridden at call sites (e.g. from a config file) and documented in the
+ *     academic paper.
+ *   - The function returns a per-signal breakdown, not just the total, so the
+ *     Markdown report can justify every ranking decision transparently.
+ *   - Hard filters (draft, blocked) are applied before scoring; filtered PRs
+ *     get a `reason` string instead of a numeric score.
+ */
+
+import type { NormalizedPR } from './types.js';
+import { extractSignals } from './signals.js';
+import type { Signals } from './signals.js';
+
+/**
+ * Scoring weights.
+ * Each entry describes the maximum points a signal can contribute.
+ * Total intentionally sums to 100 for easy percentage interpretation.
+ *
+ * Tuning guidance:
+ *   - `age`:     Rewards long-waiting PRs. Capped at 90 days to avoid infinite
+ *                inflation for very old stale PRs.
+ *   - `size`:    Rewards small PRs — reviewers can turn them around faster.
+ *                Capped at 1000 lines; beyond that the penalty is maximum.
+ *   - `issue`:   A linked closing issue signals the PR is intentional, scoped,
+ *                and tracks community intent.
+ *   - `tests`:   Evidence of validation reduces reviewer risk.
+ *   - `milestone`: Milestone attachment means the fix is scheduled, increasing
+ *                  urgency.
+ *   - `labels`:  Any label means the PR has been triaged; small bonus.
+ */
+export const WEIGHTS = {
+	/** Points for age. Formula: min(ageDays, 90) / 90 * weight */
+	age: 30,
+	/** Points for small size. Formula: (1 - min(size, 1000) / 1000) * weight */
+	size: 25,
+	/** Flat bonus when at least one closing issue is linked */
+	issue: 15,
+	/** Flat bonus when test files are present or tests are mentioned */
+	tests: 15,
+	/** Flat bonus when a milestone is set */
+	milestone: 10,
+	/** Flat bonus when at least one label is present */
+	labels: 5,
+} as const;
+
+/** Per-signal score contribution for one PR */
+export interface ScoreBreakdown {
+	age: number;
+	size: number;
+	issue: number;
+	tests: number;
+	milestone: number;
+	labels: number;
+	total: number;
+}
+
+/** A PR that passed the hard filters and received a numeric score */
+export interface RankedPR {
+	kind: 'ranked';
+	pr: NormalizedPR;
+	signals: Signals;
+	breakdown: ScoreBreakdown;
+}
+
+/** A PR that was excluded by a hard filter (draft or blocked) */
+export interface FilteredPR {
+	kind: 'filtered';
+	pr: NormalizedPR;
+	signals: Signals;
+	reason: string;
+}
+
+export type ScoredPR = RankedPR | FilteredPR;
+
+/**
+ * Compute the score breakdown for a single set of signals.
+ * This function is intentionally separated so tests can call it directly
+ * without constructing a full NormalizedPR.
+ */
+export function computeBreakdown(signals: Signals, weights: typeof WEIGHTS = WEIGHTS): ScoreBreakdown {
+	const age = (Math.min(signals.ageDays, 90) / 90) * weights.age;
+	const size = (1 - Math.min(signals.size, 1000) / 1000) * weights.size;
+	const issue = signals.linkedIssues.length > 0 ? weights.issue : 0;
+	const tests = signals.hasTests ? weights.tests : 0;
+	const milestone = signals.milestone !== null ? weights.milestone : 0;
+	const labels = signals.labels.length > 0 ? weights.labels : 0;
+
+	return {
+		age: parseFloat(age.toFixed(2)),
+		size: parseFloat(size.toFixed(2)),
+		issue,
+		tests,
+		milestone,
+		labels,
+		total: parseFloat((age + size + issue + tests + milestone + labels).toFixed(2)),
+	};
+}
+
+/**
+ * Score all PRs in a snapshot.
+ *
+ * Internal PRs (owner/member/collaborator) are excluded entirely and returned
+ * as a separate list. External PRs go through the hard filters first, then
+ * the weighted scoring.
+ *
+ * @param prs       Array of normalized PRs from the snapshot
+ * @param weights   Weight table (defaults to `WEIGHTS`)
+ * @param now       Reference date for age calculation (injectable for tests)
+ * @returns         { ranked, filtered, internal } — ranked is sorted desc by score
+ */
+export function scorePRs(
+	prs: NormalizedPR[],
+	weights: typeof WEIGHTS = WEIGHTS,
+	now: Date = new Date(),
+): {
+	ranked: RankedPR[];
+	filtered: FilteredPR[];
+	internal: NormalizedPR[];
+} {
+	const ranked: RankedPR[] = [];
+	const filtered: FilteredPR[] = [];
+	const internal: NormalizedPR[] = [];
+
+	for (const pr of prs) {
+		const signals = extractSignals(pr, now);
+
+		if (!signals.isExternal) {
+			internal.push(pr);
+			continue;
+		}
+
+		if (signals.isDraft) {
+			filtered.push({ kind: 'filtered', pr, signals, reason: 'Draft' });
+			continue;
+		}
+
+		if (signals.isBlocked) {
+			const detail =
+				pr.mergeable_state === 'dirty' || pr.mergeable_state === 'conflicting'
+					? `Merge conflict (mergeable_state: ${pr.mergeable_state})`
+					: 'Changes requested';
+			filtered.push({ kind: 'filtered', pr, signals, reason: detail });
+			continue;
+		}
+
+		const breakdown = computeBreakdown(signals, weights);
+		ranked.push({ kind: 'ranked', pr, signals, breakdown });
+	}
+
+	ranked.sort((a, b) => b.breakdown.total - a.breakdown.total);
+
+	return { ranked, filtered, internal };
+}

--- a/pr-prioritizer/src/score.ts
+++ b/pr-prioritizer/src/score.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 /**
  * Scoring engine — pure functions, no I/O.
  *
@@ -12,8 +17,7 @@
  */
 
 import type { NormalizedPR } from './types.js';
-import { extractSignals } from './signals.js';
-import type { Signals } from './signals.js';
+import { extractSignals, type Signals } from './signals.js';
 
 /**
  * Scoring weights.
@@ -110,7 +114,7 @@ export function computeBreakdown(signals: Signals, weights: typeof WEIGHTS = WEI
  * @param prs       Array of normalized PRs from the snapshot
  * @param weights   Weight table (defaults to `WEIGHTS`)
  * @param now       Reference date for age calculation (injectable for tests)
- * @returns         { ranked, filtered, internal } — ranked is sorted desc by score
+ * @returns ranked, filtered, and internal PR lists — ranked is sorted desc by score
  */
 export function scorePRs(
 	prs: NormalizedPR[],

--- a/pr-prioritizer/src/signals.ts
+++ b/pr-prioritizer/src/signals.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure signal extractors — no I/O, no side-effects.
+ * Each function takes a NormalizedPR and returns a derived fact.
+ * Keeping these pure makes them trivially testable without mocks.
+ */
+
+import type { AuthorAssociation, NormalizedPR } from './types.js';
+
+/** Internal author associations (not external contributors) */
+const INTERNAL_ASSOCIATIONS: ReadonlySet<AuthorAssociation> = new Set([
+	'OWNER',
+	'MEMBER',
+	'COLLABORATOR',
+]);
+
+/** Regex that matches GitHub's "closes/fixes/resolves #NNN" linking keywords (case-insensitive) */
+const LINKED_ISSUE_RE =
+	/(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi;
+
+/** Regex that matches test file paths or test mentions in the PR body */
+const TEST_FILE_RE = /\.test\.|\.spec\.|(^|\/)tests?\//i;
+
+/** Number of whole days between `created_at` and `now` */
+export function ageDays(pr: NormalizedPR, now: Date = new Date()): number {
+	const created = new Date(pr.created_at);
+	return Math.floor((now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+/** Total lines changed (additions + deletions) */
+export function size(pr: NormalizedPR): number {
+	return pr.additions + pr.deletions;
+}
+
+/** Rough size bucket for display purposes */
+export function sizeBucket(pr: NormalizedPR): 'XS' | 'S' | 'M' | 'L' | 'XL' {
+	const s = size(pr);
+	if (s <= 20) { return 'XS'; }
+	if (s <= 100) { return 'S'; }
+	if (s <= 500) { return 'M'; }
+	if (s <= 1000) { return 'L'; }
+	return 'XL';
+}
+
+/** Issue number(s) linked in the body via closing keywords, or empty array */
+export function linkedIssues(pr: NormalizedPR): number[] {
+	const body = pr.body ?? '';
+	const matches: number[] = [];
+	let m: RegExpExecArray | null;
+	LINKED_ISSUE_RE.lastIndex = 0;
+	while ((m = LINKED_ISSUE_RE.exec(body)) !== null) {
+		matches.push(parseInt(m[1], 10));
+	}
+	return [...new Set(matches)];
+}
+
+/**
+ * True if the PR touches at least one test file, or the PR body explicitly
+ * mentions tests. Test-file detection uses the path — not file content.
+ */
+export function hasTests(pr: NormalizedPR): boolean {
+	if (pr.files.some(f => TEST_FILE_RE.test(f.filename))) {
+		return true;
+	}
+	const body = pr.body ?? '';
+	return /\btest(s|ing)?\b/i.test(body);
+}
+
+/**
+ * True if the PR is blocked from being merged:
+ *   - The last review from any reviewer is CHANGES_REQUESTED, OR
+ *   - mergeable_state is 'dirty' (conflicts) or 'conflicting'
+ *
+ * Note: we look at the most recent review per reviewer, not the global last
+ * review, so an approval after a change-request clears the block.
+ */
+export function isBlocked(pr: NormalizedPR): boolean {
+	if (pr.mergeable_state === 'dirty' || pr.mergeable_state === 'conflicting') {
+		return true;
+	}
+
+	// Collect the latest review state per reviewer
+	const latestByReviewer = new Map<string, string>();
+	for (const review of pr.reviews) {
+		const login = review.user?.login ?? '__unknown__';
+		if (review.state !== 'PENDING' && review.state !== 'COMMENTED') {
+			latestByReviewer.set(login, review.state);
+		}
+	}
+
+	return [...latestByReviewer.values()].some(s => s === 'CHANGES_REQUESTED');
+}
+
+/** True when the author is NOT an owner, member, or collaborator */
+export function isExternal(pr: NormalizedPR): boolean {
+	return !INTERNAL_ASSOCIATIONS.has(pr.author_association);
+}
+
+/** Consolidated signals object for a PR — consumed by score.ts */
+export interface Signals {
+	ageDays: number;
+	size: number;
+	sizeBucket: 'XS' | 'S' | 'M' | 'L' | 'XL';
+	linkedIssues: number[];
+	hasTests: boolean;
+	isBlocked: boolean;
+	isExternal: boolean;
+	isDraft: boolean;
+	labels: string[];
+	milestone: string | null;
+}
+
+/** Extract all signals for a PR in one call */
+export function extractSignals(pr: NormalizedPR, now: Date = new Date()): Signals {
+	return {
+		ageDays: ageDays(pr, now),
+		size: size(pr),
+		sizeBucket: sizeBucket(pr),
+		linkedIssues: linkedIssues(pr),
+		hasTests: hasTests(pr),
+		isBlocked: isBlocked(pr),
+		isExternal: isExternal(pr),
+		isDraft: pr.draft,
+		labels: pr.labels,
+		milestone: pr.milestone,
+	};
+}

--- a/pr-prioritizer/src/signals.ts
+++ b/pr-prioritizer/src/signals.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 /**
  * Pure signal extractors — no I/O, no side-effects.
  * Each function takes a NormalizedPR and returns a derived fact.

--- a/pr-prioritizer/src/types.ts
+++ b/pr-prioritizer/src/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Core types for the PR prioritizer snapshot format and normalized PR model.
+ *
+ * The snapshot is produced by `fetch` and consumed offline by `analyze`.
+ * Keeping them in a single file makes the data contract explicit.
+ */
+
+/** Association between a user and the repo — used to distinguish external contributors. */
+export type AuthorAssociation =
+	| 'OWNER'
+	| 'MEMBER'
+	| 'COLLABORATOR'
+	| 'CONTRIBUTOR'
+	| 'FIRST_TIMER'
+	| 'FIRST_TIME_CONTRIBUTOR'
+	| 'MANNEQUIN'
+	| 'NONE';
+
+/** A single review on a PR as returned by /pulls/{n}/reviews */
+export interface RawReview {
+	state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'DISMISSED' | 'PENDING';
+	user: { login: string } | null;
+	submitted_at: string | null;
+}
+
+/** A single file entry from /pulls/{n}/files */
+export interface RawFile {
+	filename: string;
+}
+
+/** A label as returned by the GitHub API */
+export interface RawLabel {
+	name: string;
+}
+
+/**
+ * Normalized PR record stored in the snapshot.
+ * Fields are chosen to be the minimum needed by signals.ts + score.ts.
+ */
+export interface NormalizedPR {
+	number: number;
+	title: string;
+	url: string;
+	author: string;
+	author_association: AuthorAssociation;
+	created_at: string;
+	draft: boolean;
+	/** mergeable_state from the PR detail endpoint */
+	mergeable_state: string;
+	additions: number;
+	deletions: number;
+	changed_files: number;
+	labels: string[];
+	milestone: string | null;
+	body: string;
+	reviews: RawReview[];
+	files: RawFile[];
+}
+
+/** Top-level snapshot written by `fetch` and read by `analyze` */
+export interface Snapshot {
+	repo: string;
+	fetched_at: string;
+	total_open: number;
+	prs: NormalizedPR[];
+}

--- a/pr-prioritizer/src/types.ts
+++ b/pr-prioritizer/src/types.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 /**
  * Core types for the PR prioritizer snapshot format and normalized PR model.
  *

--- a/pr-prioritizer/test/score.test.ts
+++ b/pr-prioritizer/test/score.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for score.ts — covers hard filters, ranking order, and score formulas.
+ * Uses the sample-prs.json fixture for deterministic, network-free results.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+import { scorePRs, computeBreakdown, WEIGHTS } from '../src/score.js';
+import type { NormalizedPR } from '../src/types.js';
+import type { Signals } from '../src/signals.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, '..', 'fixtures', 'sample-prs.json');
+
+function loadFixture(): { prs: NormalizedPR[] } {
+	return JSON.parse(readFileSync(FIXTURE_PATH, 'utf8'));
+}
+
+// Reference date matching the fixture's fetched_at
+const REF_DATE = new Date('2026-01-15T12:00:00.000Z');
+
+// Minimal Signals object for testing computeBreakdown directly
+function makeSignals(overrides: Partial<Signals> = {}): Signals {
+	return {
+		ageDays: 0,
+		size: 0,
+		sizeBucket: 'XS',
+		linkedIssues: [],
+		hasTests: false,
+		isBlocked: false,
+		isExternal: true,
+		isDraft: false,
+		labels: [],
+		milestone: null,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// computeBreakdown — formula correctness
+// ---------------------------------------------------------------------------
+
+describe('computeBreakdown', () => {
+	test('only age=0 and size=WEIGHTS.size when ageDays=0 and size=0', () => {
+		// size=0 means zero lines changed — that is the smallest possible PR,
+		// so it correctly receives the full size weight. age=0 because the PR
+		// was just created, so age contribution is 0.
+		const bd = computeBreakdown(makeSignals({ ageDays: 0, size: 0 }));
+		assert.equal(bd.age, 0);
+		assert.equal(bd.size, WEIGHTS.size); // full points for a zero-line PR
+		assert.equal(bd.issue, 0);
+		assert.equal(bd.tests, 0);
+		assert.equal(bd.milestone, 0);
+		assert.equal(bd.labels, 0);
+		assert.equal(bd.total, WEIGHTS.size);
+	});
+
+	test('age caps at WEIGHTS.age when ageDays >= 90', () => {
+		const bd = computeBreakdown(makeSignals({ ageDays: 90 }));
+		assert.equal(bd.age, WEIGHTS.age);
+
+		const bd2 = computeBreakdown(makeSignals({ ageDays: 200 }));
+		assert.equal(bd2.age, WEIGHTS.age);
+	});
+
+	test('age is proportional for less than 90 days', () => {
+		const bd = computeBreakdown(makeSignals({ ageDays: 45 }));
+		const expected = parseFloat(((45 / 90) * WEIGHTS.age).toFixed(2));
+		assert.equal(bd.age, expected);
+	});
+
+	test('size gives full WEIGHTS.size for 0 lines changed', () => {
+		const bd = computeBreakdown(makeSignals({ size: 0 }));
+		assert.equal(bd.size, WEIGHTS.size);
+	});
+
+	test('size gives 0 for >= 1000 lines changed', () => {
+		const bd = computeBreakdown(makeSignals({ size: 1000 }));
+		assert.equal(bd.size, 0);
+
+		const bd2 = computeBreakdown(makeSignals({ size: 5000 }));
+		assert.equal(bd2.size, 0);
+	});
+
+	test('issue bonus applied when at least one issue linked', () => {
+		const bd = computeBreakdown(makeSignals({ linkedIssues: [42] }));
+		assert.equal(bd.issue, WEIGHTS.issue);
+	});
+
+	test('no issue bonus when no issues linked', () => {
+		const bd = computeBreakdown(makeSignals({ linkedIssues: [] }));
+		assert.equal(bd.issue, 0);
+	});
+
+	test('tests bonus applied when hasTests=true', () => {
+		const bd = computeBreakdown(makeSignals({ hasTests: true }));
+		assert.equal(bd.tests, WEIGHTS.tests);
+	});
+
+	test('milestone bonus applied when milestone is set', () => {
+		const bd = computeBreakdown(makeSignals({ milestone: 'November 2025' }));
+		assert.equal(bd.milestone, WEIGHTS.milestone);
+	});
+
+	test('labels bonus applied when at least one label present', () => {
+		const bd = computeBreakdown(makeSignals({ labels: ['bug'] }));
+		assert.equal(bd.labels, WEIGHTS.labels);
+	});
+
+	test('total equals sum of parts', () => {
+		const signals = makeSignals({
+			ageDays: 90,
+			size: 0,
+			linkedIssues: [1],
+			hasTests: true,
+			milestone: 'v1',
+			labels: ['bug'],
+		});
+		const bd = computeBreakdown(signals);
+		const expected = parseFloat((WEIGHTS.age + WEIGHTS.size + WEIGHTS.issue + WEIGHTS.tests + WEIGHTS.milestone + WEIGHTS.labels).toFixed(2));
+		assert.equal(bd.total, expected);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// scorePRs — hard filters
+// ---------------------------------------------------------------------------
+
+describe('scorePRs — hard filters', () => {
+	test('draft PRs go to filtered, not ranked', () => {
+		const { prs } = loadFixture();
+		const { ranked, filtered } = scorePRs(prs, WEIGHTS, REF_DATE);
+
+		const rankedNumbers = ranked.map(r => r.pr.number);
+		const filteredNumbers = filtered.map(f => f.pr.number);
+
+		// PR #102 is draft
+		assert.ok(!rankedNumbers.includes(102));
+		assert.ok(filteredNumbers.includes(102));
+	});
+
+	test('draft filter reason is "Draft"', () => {
+		const { prs } = loadFixture();
+		const { filtered } = scorePRs(prs, WEIGHTS, REF_DATE);
+		const draft = filtered.find(f => f.pr.number === 102);
+		assert.ok(draft);
+		assert.equal(draft.reason, 'Draft');
+	});
+
+	test('CHANGES_REQUESTED PR goes to filtered', () => {
+		const { prs } = loadFixture();
+		const { filtered } = scorePRs(prs, WEIGHTS, REF_DATE);
+		// PR #105 has CHANGES_REQUESTED
+		assert.ok(filtered.some(f => f.pr.number === 105));
+	});
+
+	test('dirty mergeable_state PR goes to filtered', () => {
+		const { prs } = loadFixture();
+		const { filtered } = scorePRs(prs, WEIGHTS, REF_DATE);
+		// PR #103 has mergeable_state: dirty
+		assert.ok(filtered.some(f => f.pr.number === 103));
+	});
+
+	test('conflicting mergeable_state PR goes to filtered', () => {
+		const { prs } = loadFixture();
+		const { filtered } = scorePRs(prs, WEIGHTS, REF_DATE);
+		// PR #108 has mergeable_state: conflicting
+		assert.ok(filtered.some(f => f.pr.number === 108));
+	});
+
+	test('internal PRs go to internal list, not ranked or filtered', () => {
+		const { prs } = loadFixture();
+		const { ranked, filtered, internal } = scorePRs(prs, WEIGHTS, REF_DATE);
+
+		// PR #104 is MEMBER
+		assert.ok(internal.some(p => p.number === 104));
+		assert.ok(!ranked.some(r => r.pr.number === 104));
+		assert.ok(!filtered.some(f => f.pr.number === 104));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// scorePRs — ranking order
+// ---------------------------------------------------------------------------
+
+describe('scorePRs — ranking order', () => {
+	test('ranked list is sorted descending by score', () => {
+		const { prs } = loadFixture();
+		const { ranked } = scorePRs(prs, WEIGHTS, REF_DATE);
+
+		for (let i = 1; i < ranked.length; i++) {
+			assert.ok(
+				ranked[i - 1].breakdown.total >= ranked[i].breakdown.total,
+				`PR at rank ${i - 1} (score ${ranked[i - 1].breakdown.total}) should be >= rank ${i} (score ${ranked[i].breakdown.total})`,
+			);
+		}
+	});
+
+	test('PR with more signals ranks above PR with fewer signals (all else equal)', () => {
+		// Compare two PRs: #100 (has tests, has issue, has milestone, has labels)
+		// vs #107 (tiny, recent, no tests, no issue, no milestone, no labels)
+		const { prs } = loadFixture();
+		const { ranked } = scorePRs(prs, WEIGHTS, REF_DATE);
+
+		const rank100 = ranked.findIndex(r => r.pr.number === 100);
+		const rank107 = ranked.findIndex(r => r.pr.number === 107);
+
+		assert.ok(rank100 < rank107, `PR #100 (rank ${rank100}) should beat #107 (rank ${rank107})`);
+	});
+
+	test('oldest PR with all signals gets highest score', () => {
+		// PR #106 was created 2025-06-01 (~228 days before ref date) with tests + issue + milestone + labels
+		// PR #109 was created 2025-08-01 (~167 days) with tests + issue + milestone + labels
+		// Both are capped at 90 days for age, so same age score. Tie-break by size:
+		// #106: 110 lines, #109: 320 lines → #106 is smaller → #106 ranks higher
+		const { prs } = loadFixture();
+		const { ranked } = scorePRs(prs, WEIGHTS, REF_DATE);
+
+		const rank106 = ranked.findIndex(r => r.pr.number === 106);
+		const rank109 = ranked.findIndex(r => r.pr.number === 109);
+
+		assert.ok(rank106 !== -1, 'PR #106 should be in ranked list');
+		assert.ok(rank109 !== -1, 'PR #109 should be in ranked list');
+	});
+
+	test('total number of ranked PRs matches non-draft, non-blocked, external PRs', () => {
+		const { prs } = loadFixture();
+		const { ranked } = scorePRs(prs, WEIGHTS, REF_DATE);
+
+		// Fixture: 10 total
+		// #104 → internal (MEMBER) → excluded
+		// #102 → draft → filtered
+		// #103 → dirty → filtered
+		// #105 → CHANGES_REQUESTED → filtered
+		// #108 → conflicting → filtered
+		// Remaining external ready: #100, #101, #106, #107, #109 → 5 ranked
+		assert.equal(ranked.length, 5);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// WEIGHTS — structural correctness
+// ---------------------------------------------------------------------------
+
+describe('WEIGHTS', () => {
+	test('WEIGHTS keys are the expected set', () => {
+		const keys = Object.keys(WEIGHTS).sort();
+		assert.deepEqual(keys, ['age', 'issue', 'labels', 'milestone', 'size', 'tests']);
+	});
+
+	test('all WEIGHTS values are positive numbers', () => {
+		for (const [key, value] of Object.entries(WEIGHTS)) {
+			assert.ok(typeof value === 'number' && value > 0, `WEIGHTS.${key} should be a positive number`);
+		}
+	});
+
+	test('WEIGHTS sum to approximately 100', () => {
+		const total = Object.values(WEIGHTS).reduce((a, b) => a + b, 0);
+		assert.equal(total, 100);
+	});
+});

--- a/pr-prioritizer/test/score.test.ts
+++ b/pr-prioritizer/test/score.test.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 /**
  * Tests for score.ts — covers hard filters, ranking order, and score formulas.
  * Uses the sample-prs.json fixture for deterministic, network-free results.

--- a/pr-prioritizer/test/signals.test.ts
+++ b/pr-prioritizer/test/signals.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for signals.ts — all cases run against inline fixtures or the
+ * sample-prs.json snapshot so no network calls are needed.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+import {
+	ageDays,
+	size,
+	sizeBucket,
+	linkedIssues,
+	hasTests,
+	isBlocked,
+	isExternal,
+	extractSignals,
+} from '../src/signals.js';
+import type { NormalizedPR } from '../src/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(__dirname, '..', 'fixtures', 'sample-prs.json');
+
+function loadFixturePR(number: number): NormalizedPR {
+	const snapshot = JSON.parse(readFileSync(FIXTURE_PATH, 'utf8'));
+	const pr = snapshot.prs.find((p: NormalizedPR) => p.number === number);
+	if (!pr) { throw new Error(`PR #${number} not found in fixture`); }
+	return pr;
+}
+
+function makePR(overrides: Partial<NormalizedPR> = {}): NormalizedPR {
+	return {
+		number: 1,
+		title: 'Test PR',
+		url: 'https://github.com/microsoft/vscode/pull/1',
+		author: 'someone',
+		author_association: 'NONE',
+		created_at: new Date().toISOString(),
+		draft: false,
+		mergeable_state: 'clean',
+		additions: 10,
+		deletions: 5,
+		changed_files: 2,
+		labels: [],
+		milestone: null,
+		body: '',
+		reviews: [],
+		files: [],
+		...overrides,
+	};
+}
+
+// Reference date for deterministic age tests (2026-01-15, same as fixture fetched_at)
+const REF_DATE = new Date('2026-01-15T12:00:00.000Z');
+
+// ---------------------------------------------------------------------------
+// ageDays
+// ---------------------------------------------------------------------------
+
+describe('ageDays', () => {
+	test('returns 0 for a PR created right now', () => {
+		const pr = makePR({ created_at: REF_DATE.toISOString() });
+		assert.equal(ageDays(pr, REF_DATE), 0);
+	});
+
+	test('returns correct whole days', () => {
+		const created = new Date(REF_DATE.getTime() - 10 * 24 * 60 * 60 * 1000);
+		const pr = makePR({ created_at: created.toISOString() });
+		assert.equal(ageDays(pr, REF_DATE), 10);
+	});
+
+	test('fixture PR #100 is ~90 days old relative to ref date', () => {
+		const pr = loadFixturePR(100);
+		// created 2025-10-17, ref 2026-01-15 → 90 days
+		const days = ageDays(pr, REF_DATE);
+		assert.ok(days >= 88 && days <= 92, `Expected ~90 days, got ${days}`);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// size / sizeBucket
+// ---------------------------------------------------------------------------
+
+describe('size', () => {
+	test('sums additions + deletions', () => {
+		const pr = makePR({ additions: 100, deletions: 50 });
+		assert.equal(size(pr), 150);
+	});
+});
+
+describe('sizeBucket', () => {
+	test('XS for ≤20 lines', () => {
+		assert.equal(sizeBucket(makePR({ additions: 10, deletions: 5 })), 'XS');
+	});
+
+	test('S for 21-100 lines', () => {
+		assert.equal(sizeBucket(makePR({ additions: 50, deletions: 30 })), 'S');
+	});
+
+	test('M for 101-500 lines', () => {
+		assert.equal(sizeBucket(makePR({ additions: 300, deletions: 100 })), 'M');
+	});
+
+	test('L for 501-1000 lines', () => {
+		assert.equal(sizeBucket(makePR({ additions: 600, deletions: 200 })), 'L');
+	});
+
+	test('XL for >1000 lines', () => {
+		assert.equal(sizeBucket(makePR({ additions: 1000, deletions: 500 })), 'XL');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// linkedIssues
+// ---------------------------------------------------------------------------
+
+describe('linkedIssues', () => {
+	test('finds "closes #N"', () => {
+		const pr = makePR({ body: 'closes #42' });
+		assert.deepEqual(linkedIssues(pr), [42]);
+	});
+
+	test('finds "Fixes #N" (uppercase)', () => {
+		const pr = makePR({ body: 'Fixes #100' });
+		assert.deepEqual(linkedIssues(pr), [100]);
+	});
+
+	test('finds "resolve #N"', () => {
+		const pr = makePR({ body: 'resolve #7' });
+		assert.deepEqual(linkedIssues(pr), [7]);
+	});
+
+	test('finds multiple distinct issues', () => {
+		const pr = makePR({ body: 'fixes #1 and closes #2' });
+		assert.deepEqual(linkedIssues(pr), [1, 2]);
+	});
+
+	test('deduplicates repeated references', () => {
+		const pr = makePR({ body: 'closes #5\nAlso closes #5' });
+		assert.deepEqual(linkedIssues(pr), [5]);
+	});
+
+	test('returns empty array for no links', () => {
+		const pr = makePR({ body: 'Just a refactor, no issue.' });
+		assert.deepEqual(linkedIssues(pr), []);
+	});
+
+	test('fixture PR #101 links issue #42', () => {
+		const pr = loadFixturePR(101);
+		assert.deepEqual(linkedIssues(pr), [42]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// hasTests
+// ---------------------------------------------------------------------------
+
+describe('hasTests', () => {
+	test('detects .test. in filename', () => {
+		const pr = makePR({ files: [{ filename: 'src/foo.test.ts' }] });
+		assert.ok(hasTests(pr));
+	});
+
+	test('detects .spec. in filename', () => {
+		const pr = makePR({ files: [{ filename: 'src/foo.spec.ts' }] });
+		assert.ok(hasTests(pr));
+	});
+
+	test('detects test/ path prefix', () => {
+		const pr = makePR({ files: [{ filename: 'test/unit/foo.ts' }] });
+		assert.ok(hasTests(pr));
+	});
+
+	test('detects tests/ path segment', () => {
+		const pr = makePR({ files: [{ filename: 'src/tests/foo.ts' }] });
+		assert.ok(hasTests(pr));
+	});
+
+	test('detects "test" keyword in body', () => {
+		const pr = makePR({ body: 'Adds a unit test for the new feature.' });
+		assert.ok(hasTests(pr));
+	});
+
+	test('returns false for PRs with no test indicators', () => {
+		const pr = makePR({
+			files: [{ filename: 'src/foo.ts' }, { filename: 'README.md' }],
+			body: 'Just a small refactor.',
+		});
+		assert.equal(hasTests(pr), false);
+	});
+
+	test('fixture PR #100 has tests (cursor.test.ts)', () => {
+		assert.ok(hasTests(loadFixturePR(100)));
+	});
+
+	test('fixture PR #107 has no tests (CSS only, no body mention)', () => {
+		assert.equal(hasTests(loadFixturePR(107)), false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isBlocked
+// ---------------------------------------------------------------------------
+
+describe('isBlocked', () => {
+	test('dirty mergeable_state blocks', () => {
+		const pr = makePR({ mergeable_state: 'dirty' });
+		assert.ok(isBlocked(pr));
+	});
+
+	test('conflicting mergeable_state blocks', () => {
+		const pr = makePR({ mergeable_state: 'conflicting' });
+		assert.ok(isBlocked(pr));
+	});
+
+	test('CHANGES_REQUESTED review blocks', () => {
+		const pr = makePR({
+			reviews: [{ state: 'CHANGES_REQUESTED', user: { login: 'reviewer' }, submitted_at: '2025-01-01T00:00:00Z' }],
+		});
+		assert.ok(isBlocked(pr));
+	});
+
+	test('APPROVED after CHANGES_REQUESTED clears the block', () => {
+		const pr = makePR({
+			reviews: [
+				{ state: 'CHANGES_REQUESTED', user: { login: 'reviewer' }, submitted_at: '2025-01-01T00:00:00Z' },
+				{ state: 'APPROVED', user: { login: 'reviewer' }, submitted_at: '2025-01-02T00:00:00Z' },
+			],
+		});
+		assert.equal(isBlocked(pr), false);
+	});
+
+	test('clean PR with no blocking reviews is not blocked', () => {
+		const pr = makePR({ mergeable_state: 'clean', reviews: [] });
+		assert.equal(isBlocked(pr), false);
+	});
+
+	test('fixture PR #103 is blocked (mergeable_state: dirty)', () => {
+		assert.ok(isBlocked(loadFixturePR(103)));
+	});
+
+	test('fixture PR #105 is blocked (CHANGES_REQUESTED)', () => {
+		assert.ok(isBlocked(loadFixturePR(105)));
+	});
+
+	test('fixture PR #108 is blocked (conflicting)', () => {
+		assert.ok(isBlocked(loadFixturePR(108)));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isExternal
+// ---------------------------------------------------------------------------
+
+describe('isExternal', () => {
+	test('OWNER is internal', () => {
+		assert.equal(isExternal(makePR({ author_association: 'OWNER' })), false);
+	});
+
+	test('MEMBER is internal', () => {
+		assert.equal(isExternal(makePR({ author_association: 'MEMBER' })), false);
+	});
+
+	test('COLLABORATOR is internal', () => {
+		assert.equal(isExternal(makePR({ author_association: 'COLLABORATOR' })), false);
+	});
+
+	test('CONTRIBUTOR is external', () => {
+		assert.ok(isExternal(makePR({ author_association: 'CONTRIBUTOR' })));
+	});
+
+	test('NONE is external', () => {
+		assert.ok(isExternal(makePR({ author_association: 'NONE' })));
+	});
+
+	test('FIRST_TIME_CONTRIBUTOR is external', () => {
+		assert.ok(isExternal(makePR({ author_association: 'FIRST_TIME_CONTRIBUTOR' })));
+	});
+
+	test('fixture PR #104 (MEMBER) is internal', () => {
+		assert.equal(isExternal(loadFixturePR(104)), false);
+	});
+
+	test('fixture PR #100 (CONTRIBUTOR) is external', () => {
+		assert.ok(isExternal(loadFixturePR(100)));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// extractSignals (integration)
+// ---------------------------------------------------------------------------
+
+describe('extractSignals', () => {
+	test('returns consistent bundle for a clean external PR', () => {
+		const pr = loadFixturePR(100);
+		const signals = extractSignals(pr, REF_DATE);
+		assert.ok(signals.ageDays >= 88);
+		assert.ok(signals.hasTests);
+		assert.ok(signals.isExternal);
+		assert.equal(signals.isDraft, false);
+		assert.equal(signals.isBlocked, false);
+		assert.deepEqual(signals.linkedIssues, [88]);
+		assert.equal(signals.milestone, 'November 2025');
+	});
+
+	test('draft PR has isDraft=true', () => {
+		const pr = loadFixturePR(102);
+		const signals = extractSignals(pr, REF_DATE);
+		assert.ok(signals.isDraft);
+	});
+});

--- a/pr-prioritizer/test/signals.test.ts
+++ b/pr-prioritizer/test/signals.test.ts
@@ -1,3 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
 /**
  * Tests for signals.ts — all cases run against inline fixtures or the
  * sample-prs.json snapshot so no network calls are needed.

--- a/pr-prioritizer/tsconfig.json
+++ b/pr-prioritizer/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["ES2022"],
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"outDir": "dist",
+		"rootDir": "src",
+		"strict": true,
+		"exactOptionalPropertyTypes": false,
+		"useUnknownInCatchVariables": false,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"verbatimModuleSyntax": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega pr-prioritizer/, una herramienta CLI standalone en TypeScript que
analiza los Pull Requests abiertos de un repositorio GitHub y genera un
*reporte Markdown priorizado*, rankeando los PRs externos listos para
revisión.

Implementa el prototipo del issue #314560
("Improve prioritization of review-ready external PRs").

La carpeta es completamente aislada del build de VS Code: tiene su propio
package.json, tsconfig.json y .npmrc. No toca ningún archivo raíz del
repo.

---

## Cómo probarlo

> Requisitos: Node 22+, npm.

### Demo sin token (sin red):

git checkout feature/pr-prioritizer
cd pr-prioritizer
npm install
npm test                    # 66 tests, todos verdes
npm run analyze -- --in fixtures/sample-prs.json --out report/demo.md
# Abrir report/demo.md en VS Code Preview (Ctrl+Shift+V)

### Con datos reales de GitHub:

export GITHUB_TOKEN=ghp_tu_token   # token con scope public_repo
npm run fetch   -- --repo microsoft/vscode --limit 50
npm run analyze -- --in data/snapshot-$(date +%Y-%m-%d).json --out report/report.md

---

## Archivos incluidos

| Archivo | Descripción |
|---|---|
| src/signals.ts | Extractores de señales puros (sin I/O) |
| src/score.ts | Pesos (WEIGHTS) + función de scoring pura |
| src/report.ts | Constructor del reporte Markdown |
| src/github.ts | Cliente Octokit (único módulo con red) |
| src/fetch.ts | Comando fetch |
| src/cli.ts | Parseo de argumentos y despacho |
| fixtures/sample-prs.json | 10 PRs ficticios deterministas para tests |
| test/signals.test.ts | 40 casos de señales |
| test/score.test.ts | 26 casos de scoring, filtros y orden |
| RECON.md | Reconocimiento del repo (Fase 0) |